### PR TITLE
👷 (workflow): Maven Should Only Deploy Rage4J and Rage4J-Assert

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,8 @@ jobs:
           mvn -B formatter:validate
           mvn -B -U -fae clean package
           mvn cyclonedx:makeAggregateBom
-      - name: Publish package
-        run: mvn --batch-mode deploy
+      - name: Publish packages
+        run: |
+          mvn --batch-mode deploy -pl rage4j,rage4j-assert -am
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
makes that rage4j-reactor doesn't get deployed anymore