### PR TITLE
🦺 Enhance claim validation in faithfulness metric

### DIFF
--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessBot.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessBot.java
@@ -11,7 +11,14 @@ public interface FaithfulnessBot
 	@UserMessage("Extract claims from this text: '''{{text}}'''")
 	ArrayResponse extractClaims(@V("text") String text);
 
-	@SystemMessage("You are a fact checker llm. Your are provided with a context and a fact. You must answer whether this fact can be inferred from the context.")
-	@UserMessage("Decide whether this fact '{{claim}}' can be inferred from this context '{{info}}'")
+	@SystemMessage("""
+		You are a fact checker LLM. You are provided with a context and a claim. \
+		Determine whether the claim can be inferred from the context. \
+		A claim can be inferred if it follows directly from the context OR if it can be derived through reasoning, \
+		including: arithmetic calculations (e.g. summing numbers, counting items), \
+		parsing structured data formats such as JSON or XML, \
+		or logical implications of the context content. \
+		Answer only true or false.""")
+	@UserMessage("Can the following claim be inferred from the context? Claim: '{{claim}}' Context: '{{info}}'")
 	Boolean canBeInferred(@V("info") String info, @V("claim") String claim);
 }


### PR DESCRIPTION
With these adjustments, claim validation was much more stable in my tests.

Before:
<img width="910" height="416" alt="image" src="https://github.com/user-attachments/assets/f32f7290-0d82-4e98-b30b-87a49cd6d118" />

After:
<img width="907" height="410" alt="image" src="https://github.com/user-attachments/assets/8c292429-961b-47df-9dc2-387d194ef803" />
