### PR TITLE
Feature/image input support

### DIFF
--- a/dev.rage4j.rage4j-assert/pom.xml
+++ b/dev.rage4j.rage4j-assert/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <langchain4j.version>1.0.1</langchain4j.version>
+        <langchain4j.version>1.7.1</langchain4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
@@ -1,6 +1,5 @@
 package dev.rage4j.asserts;
 
-import java.util.List;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -22,45 +21,26 @@ import dev.rage4j.evaluation.bleuscore.BleuScoreEvaluator;
 import dev.rage4j.evaluation.faithfulness.FaithfulnessEvaluator;
 import dev.rage4j.evaluation.rougescore.RougeScoreEvaluator;
 import dev.rage4j.model.EvaluationAggregation;
-import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
 
 public class RageAssertTestCaseAssertions
 {
 	private static final Logger LOG = LoggerFactory.getLogger(RageAssertTestCaseAssertions.class);
 
+	private final Sample sample;
 	private final ChatModel chatModel;
 	private final EmbeddingModel embeddingModel;
-	private final String question;
-	private final String groundTruth;
-	private final String context;
-	private final List<Rage4jImage> images;
-	private final String answer;
 	private final boolean evaluationMode;
 	private EvaluationAggregation pendingAggregation;
 
 	private static final String MINVALUE = "Answer did not reach required min value! Evaluated value: ";
 
-	public RageAssertTestCaseAssertions(String answer, String groundTruth, String question, String context, ChatModel chatModel, EmbeddingModel embeddingModel, boolean evaluationMode)
+	public RageAssertTestCaseAssertions(Sample sample, ChatModel chatModel, EmbeddingModel embeddingModel, boolean evaluationMode)
 	{
-		this(answer, groundTruth, question, context, null, chatModel, embeddingModel, evaluationMode);
-	}
-
-	public RageAssertTestCaseAssertions(String answer, String groundTruth, String question, String context, List<Rage4jImage> images, ChatModel chatModel, EmbeddingModel embeddingModel, boolean evaluationMode)
-	{
-		this.answer = answer;
-		this.groundTruth = groundTruth;
-		this.question = question;
-		this.context = context;
-		this.images = images;
+		this.sample = sample;
 		this.chatModel = chatModel;
 		this.embeddingModel = embeddingModel;
 		this.evaluationMode = evaluationMode;
-	}
-
-	private boolean hasImages()
-	{
-		return images != null && !images.isEmpty();
 	}
 
 	/**
@@ -86,7 +66,7 @@ public class RageAssertTestCaseAssertions
 		}
 	}
 
-	private void collectEvaluation(Sample sample, Evaluation evaluation)
+	private void collectEvaluation(Evaluation evaluation)
 	{
 		if (pendingAggregation == null)
 		{
@@ -109,25 +89,15 @@ public class RageAssertTestCaseAssertions
 
 	public AssertionEvaluation assertFaithfulness(double minValue)
 	{
-		FaithfulnessEvaluator evaluator = new FaithfulnessEvaluator(chatModel, hasImages());
-		Sample.SampleBuilder sampleBuilder = Sample.builder()
-			.withAnswer(answer)
-			.withGroundTruth(groundTruth)
-			.withQuestion(question)
-			.withContext(context);
-		if (hasImages())
-		{
-			sampleBuilder.withImages(images);
-		}
-		Sample sample = sampleBuilder.build();
+		FaithfulnessEvaluator evaluator = new FaithfulnessEvaluator(chatModel, sample.hasImages());
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();
-		collectEvaluation(sample, evaluation);
+		collectEvaluation(evaluation);
 
 		if (!passed)
 		{
-			String message = MINVALUE + evaluation.getValue() + " answer: " + answer;
+			String message = MINVALUE + evaluation.getValue() + " answer: " + sample.getAnswer();
 			handleAssertionFailure(message, "Faithfulness", () -> new Rage4JFaithfulnessException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);
@@ -136,19 +106,14 @@ public class RageAssertTestCaseAssertions
 	public AssertionEvaluation assertAnswerCorrectness(double minValue)
 	{
 		AnswerCorrectnessEvaluator evaluator = new AnswerCorrectnessEvaluator(chatModel);
-		Sample sample = Sample.builder()
-			.withAnswer(answer)
-			.withGroundTruth(groundTruth)
-			.withQuestion(question)
-			.build();
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();
-		collectEvaluation(sample, evaluation);
+		collectEvaluation(evaluation);
 
 		if (!passed)
 		{
-			String message = MINVALUE + evaluation.getValue() + " answer: " + answer;
+			String message = MINVALUE + evaluation.getValue() + " answer: " + sample.getAnswer();
 			handleAssertionFailure(message, "Answer Correctness", () -> new Rage4JCorrectnessException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);
@@ -157,19 +122,14 @@ public class RageAssertTestCaseAssertions
 	public AssertionEvaluation assertAnswerRelevance(double minValue)
 	{
 		AnswerRelevanceEmbeddingEvaluator evaluator = new AnswerRelevanceEmbeddingEvaluator(chatModel, embeddingModel);
-		Sample sample = Sample.builder()
-			.withAnswer(answer)
-			.withQuestion(question)
-			.withContext(context)
-			.build();
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();
-		collectEvaluation(sample, evaluation);
+		collectEvaluation(evaluation);
 
 		if (!passed)
 		{
-			String message = assertionFailureMessage(evaluation.getValue(), minValue, answer);
+			String message = assertionFailureMessage(evaluation.getValue(), minValue, sample.getAnswer());
 			handleAssertionFailure(message, "Answer Relevance", () -> new Rage4JRelevanceException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);
@@ -183,18 +143,14 @@ public class RageAssertTestCaseAssertions
 	public AssertionEvaluation assertSemanticSimilarity(double minValue)
 	{
 		AnswerSemanticSimilarityEvaluator evaluator = new AnswerSemanticSimilarityEvaluator(embeddingModel);
-		Sample sample = Sample.builder()
-			.withAnswer(answer)
-			.withGroundTruth(groundTruth)
-			.build();
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();
-		collectEvaluation(sample, evaluation);
+		collectEvaluation(evaluation);
 
 		if (!passed)
 		{
-			String message = assertionFailureMessage(evaluation.getValue(), minValue, answer);
+			String message = assertionFailureMessage(evaluation.getValue(), minValue, sample.getAnswer());
 			handleAssertionFailure(message, "Semantic Similarity", () -> new Rage4JSimilarityException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);
@@ -203,18 +159,14 @@ public class RageAssertTestCaseAssertions
 	public AssertionEvaluation assertBleuScore(double minValue)
 	{
 		BleuScoreEvaluator evaluator = new BleuScoreEvaluator();
-		Sample sample = Sample.builder()
-			.withAnswer(answer)
-			.withGroundTruth(groundTruth)
-			.build();
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();
-		collectEvaluation(sample, evaluation);
+		collectEvaluation(evaluation);
 
 		if (!passed)
 		{
-			String message = assertionFailureMessage(evaluation.getValue(), minValue, answer);
+			String message = assertionFailureMessage(evaluation.getValue(), minValue, sample.getAnswer());
 			handleAssertionFailure(message, "BLEU Score", () -> new Rage4JBleuScoreException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);
@@ -223,18 +175,14 @@ public class RageAssertTestCaseAssertions
 	public AssertionEvaluation assertRougeScore(double minValue, RougeScoreEvaluator.RougeType rougeType, RougeScoreEvaluator.MeasureType measureType)
 	{
 		RougeScoreEvaluator evaluator = new RougeScoreEvaluator(rougeType, measureType);
-		Sample sample = Sample.builder()
-			.withAnswer(answer)
-			.withGroundTruth(groundTruth)
-			.build();
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();
-		collectEvaluation(sample, evaluation);
+		collectEvaluation(evaluation);
 
 		if (!passed)
 		{
-			String message = assertionFailureMessage(evaluation.getValue(), minValue, answer);
+			String message = assertionFailureMessage(evaluation.getValue(), minValue, sample.getAnswer());
 			handleAssertionFailure(message, "ROUGE Score", () -> new Rage4JRougeScoreException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
@@ -1,5 +1,6 @@
 package dev.rage4j.asserts;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -21,6 +22,7 @@ import dev.rage4j.evaluation.bleuscore.BleuScoreEvaluator;
 import dev.rage4j.evaluation.faithfulness.FaithfulnessEvaluator;
 import dev.rage4j.evaluation.rougescore.RougeScoreEvaluator;
 import dev.rage4j.model.EvaluationAggregation;
+import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
 
 public class RageAssertTestCaseAssertions
@@ -32,6 +34,7 @@ public class RageAssertTestCaseAssertions
 	private final String question;
 	private final String groundTruth;
 	private final String context;
+	private final List<Rage4jImage> images;
 	private final String answer;
 	private final boolean evaluationMode;
 	private EvaluationAggregation pendingAggregation;
@@ -40,13 +43,24 @@ public class RageAssertTestCaseAssertions
 
 	public RageAssertTestCaseAssertions(String answer, String groundTruth, String question, String context, ChatModel chatModel, EmbeddingModel embeddingModel, boolean evaluationMode)
 	{
+		this(answer, groundTruth, question, context, null, chatModel, embeddingModel, evaluationMode);
+	}
+
+	public RageAssertTestCaseAssertions(String answer, String groundTruth, String question, String context, List<Rage4jImage> images, ChatModel chatModel, EmbeddingModel embeddingModel, boolean evaluationMode)
+	{
 		this.answer = answer;
 		this.groundTruth = groundTruth;
 		this.question = question;
 		this.context = context;
+		this.images = images;
 		this.chatModel = chatModel;
 		this.embeddingModel = embeddingModel;
 		this.evaluationMode = evaluationMode;
+	}
+
+	private boolean hasImages()
+	{
+		return images != null && !images.isEmpty();
 	}
 
 	/**
@@ -95,13 +109,17 @@ public class RageAssertTestCaseAssertions
 
 	public AssertionEvaluation assertFaithfulness(double minValue)
 	{
-		FaithfulnessEvaluator evaluator = new FaithfulnessEvaluator(chatModel);
-		Sample sample = Sample.builder()
+		FaithfulnessEvaluator evaluator = new FaithfulnessEvaluator(chatModel, hasImages());
+		Sample.SampleBuilder sampleBuilder = Sample.builder()
 			.withAnswer(answer)
 			.withGroundTruth(groundTruth)
 			.withQuestion(question)
-			.withContext(context)
-			.build();
+			.withContext(context);
+		if (hasImages())
+		{
+			sampleBuilder.withImages(images);
+		}
+		Sample sample = sampleBuilder.build();
 		Evaluation evaluation = evaluator.evaluate(sample);
 
 		boolean passed = minValue <= evaluation.getValue();

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseBuilder.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseBuilder.java
@@ -2,12 +2,18 @@ package dev.rage4j.asserts;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.rage4j.model.Rage4jImage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 public class RageAssertTestCaseBuilder
 {
 	private String question;
 	private String groundTruth;
 	private String context;
+	private List<Rage4jImage> images;
 	private final ChatModel chatModel;
 	private final EmbeddingModel embeddingModel;
 	private final boolean evaluationMode;
@@ -37,8 +43,35 @@ public class RageAssertTestCaseBuilder
 		return this;
 	}
 
+	/**
+	 * Attaches a single image to the test case. Calling this method opts the
+	 * test case into multimodal evaluation; downstream LLM-based assertions
+	 * (e.g. {@code assertFaithfulness}) will pass the images to the configured
+	 * {@link ChatModel}, which therefore must be vision-capable.
+	 */
+	public RageAssertTestCaseBuilder image(Rage4jImage image)
+	{
+		Objects.requireNonNull(image, "image");
+		if (this.images == null)
+		{
+			this.images = new ArrayList<>();
+		}
+		this.images.add(image);
+		return this;
+	}
+
+	/**
+	 * Replaces the image list of this test case. Pass {@code null} or an empty
+	 * list to clear it.
+	 */
+	public RageAssertTestCaseBuilder images(List<Rage4jImage> images)
+	{
+		this.images = images == null ? null : new ArrayList<>(images);
+		return this;
+	}
+
 	public RageAssertTestCaseGiven when()
 	{
-		return new RageAssertTestCaseGiven(question, groundTruth, context, chatModel, embeddingModel, evaluationMode);
+		return new RageAssertTestCaseGiven(question, groundTruth, context, images, chatModel, embeddingModel, evaluationMode);
 	}
 }

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseGiven.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseGiven.java
@@ -6,6 +6,7 @@ import java.util.function.UnaryOperator;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.rage4j.model.Rage4jImage;
+import dev.rage4j.model.Sample;
 
 public class RageAssertTestCaseGiven
 {
@@ -43,6 +44,13 @@ public class RageAssertTestCaseGiven
 
 	public RageAssertTestCaseAssertions then()
 	{
-		return new RageAssertTestCaseAssertions(answer, groundTruth, question, context, images, chatLanguageModel, embeddingModel, evaluationMode);
+		Sample sample = Sample.builder()
+			.withAnswer(answer)
+			.withGroundTruth(groundTruth)
+			.withQuestion(question)
+			.withContext(context)
+			.withImages(images)
+			.build();
+		return new RageAssertTestCaseAssertions(sample, chatLanguageModel, embeddingModel, evaluationMode);
 	}
 }

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseGiven.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseGiven.java
@@ -1,25 +1,29 @@
 package dev.rage4j.asserts;
 
+import java.util.List;
 import java.util.function.UnaryOperator;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.rage4j.model.Rage4jImage;
 
 public class RageAssertTestCaseGiven
 {
 	private final String question;
 	private final String groundTruth;
 	private final String context;
+	private final List<Rage4jImage> images;
 	private String answer;
 	private final ChatModel chatLanguageModel;
 	private final EmbeddingModel embeddingModel;
 	private final boolean evaluationMode;
 
-	public RageAssertTestCaseGiven(String question, String groundTruth, String context, ChatModel chatLanguageModel, EmbeddingModel embeddingModel, boolean evaluationMode)
+	public RageAssertTestCaseGiven(String question, String groundTruth, String context, List<Rage4jImage> images, ChatModel chatLanguageModel, EmbeddingModel embeddingModel, boolean evaluationMode)
 	{
 		this.question = question;
 		this.groundTruth = groundTruth;
 		this.context = context;
+		this.images = images;
 		this.chatLanguageModel = chatLanguageModel;
 		this.embeddingModel = embeddingModel;
 		this.evaluationMode = evaluationMode;
@@ -39,6 +43,6 @@ public class RageAssertTestCaseGiven
 
 	public RageAssertTestCaseAssertions then()
 	{
-		return new RageAssertTestCaseAssertions(answer, groundTruth, question, context, chatLanguageModel, embeddingModel, evaluationMode);
+		return new RageAssertTestCaseAssertions(answer, groundTruth, question, context, images, chatLanguageModel, embeddingModel, evaluationMode);
 	}
 }

--- a/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/JsonLinesStoreTest.java
+++ b/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/JsonLinesStoreTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.rage4j.model.EvaluationAggregation;
+import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
 
 class JsonLinesStoreTest
@@ -194,6 +195,52 @@ class JsonLinesStoreTest
 		assertTrue(Files.exists(file));
 		List<String> lines = Files.readAllLines(file);
 		assertEquals(1, lines.size());
+	}
+
+	@Test
+	void testImagesPersistedAsNameList() throws IOException
+	{
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1, 2, 3 }, "image/png", "clash-1.png");
+		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/path/clash-2.jpg");
+		Sample sample = Sample.builder()
+			.withQuestion("Is this a real clash?")
+			.withContext("Position X-Y")
+			.withImages(List.of(img1, img2))
+			.build();
+
+		EvaluationAggregation aggregation = new EvaluationAggregation(sample);
+		aggregation.put("Faithfulness", 0.9);
+
+		store.storeFlush(aggregation);
+
+		List<String> lines = Files.readAllLines(file);
+		JsonNode json = objectMapper.readTree(lines.getFirst());
+		JsonNode sampleNode = json.get("sample");
+		JsonNode images = sampleNode.get("images");
+
+		assertTrue(images.isArray());
+		assertEquals(2, images.size());
+		assertEquals("clash-1.png", images.get(0).asText());
+		assertEquals("clash-2.jpg", images.get(1).asText());
+		// Bytes must NOT leak into the JSONL output
+		assertTrue(!lines.getFirst().contains("data") || !lines.getFirst().contains("AQID"));
+	}
+
+	@Test
+	void testImagesFieldOmittedWhenAbsent() throws IOException
+	{
+		Sample sample = Sample.builder()
+			.withQuestion("Test")
+			.withAnswer("Answer")
+			.build();
+		EvaluationAggregation aggregation = new EvaluationAggregation(sample);
+		aggregation.put("score", 0.5);
+
+		store.storeFlush(aggregation);
+
+		List<String> lines = Files.readAllLines(file);
+		JsonNode sampleNode = objectMapper.readTree(lines.getFirst()).get("sample");
+		assertTrue(!sampleNode.has("images"));
 	}
 
 	@Test

--- a/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/JsonLinesStoreTest.java
+++ b/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/JsonLinesStoreTest.java
@@ -200,11 +200,11 @@ class JsonLinesStoreTest
 	@Test
 	void testImagesPersistedAsNameList() throws IOException
 	{
-		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1, 2, 3 }, "image/png", "clash-1.png");
-		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/path/clash-2.jpg");
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1, 2, 3 }, "image/png", "eiffel-tower.png");
+		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/path/louvre.jpg");
 		Sample sample = Sample.builder()
-			.withQuestion("Is this a real clash?")
-			.withContext("Position X-Y")
+			.withQuestion("What landmarks are mentioned in the document?")
+			.withContext("Paris is the capital of France and home to many landmarks.")
 			.withImages(List.of(img1, img2))
 			.build();
 
@@ -220,8 +220,8 @@ class JsonLinesStoreTest
 
 		assertTrue(images.isArray());
 		assertEquals(2, images.size());
-		assertEquals("clash-1.png", images.get(0).asText());
-		assertEquals("clash-2.jpg", images.get(1).asText());
+		assertEquals("eiffel-tower.png", images.get(0).asText());
+		assertEquals("louvre.jpg", images.get(1).asText());
 		// Bytes must NOT leak into the JSONL output
 		assertTrue(!lines.getFirst().contains("data") || !lines.getFirst().contains("AQID"));
 	}

--- a/dev.rage4j.rage4j/pom.xml
+++ b/dev.rage4j.rage4j/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <langchain4j.version>1.0.1</langchain4j.version>
+        <langchain4j.version>1.7.1</langchain4j.version>
         <includedGroups />
         <excludedGroups>integration</excludedGroups>
     </properties>

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answercorrectness/AnswerCorrectnessBot.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answercorrectness/AnswerCorrectnessBot.java
@@ -17,62 +17,61 @@ public interface AnswerCorrectnessBot
 		    "{{actualAnswer}}"
 		""";
 
-
 	@SystemMessage("""
-	You are a facts analyzer LLM. Extract atomic claims (single facts) SEMANTICALLY present in BOTH ground truth and generated answer.
-	
-	Rules:
-	- Semantic match: Paraphrases count (e.g. "description of the book X is Y" == "exact description for X: Y").
-	- One fact per claim; maximize coverage.
-	- Ignore minor wording differences if meaning identical.
-	- Always fully write the claim you extracted in the output
-	
-	Example:
-	GT: "The description of the book with ID 'book-42' is: 'A historical novel about the rise and fall of an ancient empire'."
-	Answer: "The exact description of the book with ID 'book-42' is: 'A historical novel about the rise and fall of an ancient empire'."
-	Output: ["The description of the book with ID 'book-42' is: 'A historical novel about the rise and fall of an ancient empire'"]
-	""")
+		You are a facts analyzer LLM. Extract atomic claims (single facts) SEMANTICALLY present in BOTH ground truth and generated answer.
+
+		Rules:
+		- Semantic match: Paraphrases count (e.g. "description of the book X is Y" == "exact description for X: Y").
+		- One fact per claim; maximize coverage.
+		- Ignore minor wording differences if meaning identical.
+		- Always fully write the claim you extracted in the output
+
+		Example:
+		GT: "The description of the book with ID 'book-42' is: 'A historical novel about the rise and fall of an ancient empire'."
+		Answer: "The exact description of the book with ID 'book-42' is: 'A historical novel about the rise and fall of an ancient empire'."
+		Output: ["The description of the book with ID 'book-42' is: 'A historical novel about the rise and fall of an ancient empire'"]
+		""")
 	@UserMessage(USER_MESSAGE_PROMPT)
 	ArrayResponse extractTruePositiveClaims(@V("groundTruth") String groundTruth, @V("actualAnswer") String actualAnswer);
 
 	@SystemMessage("""
-	You are a facts analyzer LLM. Extract atomic claims from generated answer NOT SEMANTICALLY supported by ground truth (hallucinations/extras).
+		You are a facts analyzer LLM. Extract atomic claims from generated answer NOT SEMANTICALLY supported by ground truth (hallucinations/extras).
 
-	Rules:
-	- Semantic match: If paraphrase exists in GT, it's NOT FP.
-	- One fact per claim; high precision.
-	- Always fully write the claim you extracted in the output
+		Rules:
+		- Semantic match: If paraphrase exists in GT, it's NOT FP.
+		- One fact per claim; high precision.
+		- Always fully write the claim you extracted in the output
 
-	Example:
-	GT: "Paris is in France."
-	Answer: "Paris is the capital of France and has Eiffel Tower."
-	Output: ["Paris is the capital of France"]  // If GT doesn't support "capital"
+		Example:
+		GT: "Paris is in France."
+		Answer: "Paris is the capital of France and has Eiffel Tower."
+		Output: ["Paris is the capital of France"]  // If GT doesn't support "capital"
 
-	Example (no FP):
-	GT: "Paris is in France."
-	Answer: "France contains Paris."
-	Output: []  // Semantic match
-	""")
+		Example (no FP):
+		GT: "Paris is in France."
+		Answer: "France contains Paris."
+		Output: []  // Semantic match
+		""")
 	@UserMessage(USER_MESSAGE_PROMPT)
 	ArrayResponse extractFalsePositiveClaims(@V("groundTruth") String groundTruth, @V("actualAnswer") String actualAnswer);
 
 	@SystemMessage("""
-	You are a facts analyzer LLM. Extract atomic claims from ground truth NOT SEMANTICALLY covered by generated answer (missing info).
-	Rules:
-	- Semantic match: If paraphrase in answer covers GT claim, it's NOT FN.
-	- One fact per claim; high coverage.
-	- Always fully write the claim you extracted in the output (Do not write something like this: [ "Paris is the la..." ] instead write the full claim "Paris is the largest city of France")
+		You are a facts analyzer LLM. Extract atomic claims from ground truth NOT SEMANTICALLY covered by generated answer (missing info).
+		Rules:
+		- Semantic match: If paraphrase in answer covers GT claim, it's NOT FN.
+		- One fact per claim; high coverage.
+		- Always fully write the claim you extracted in the output (Do not write something like this: [ "Paris is the la..." ] instead write the full claim "Paris is the largest city of France")
 
-	Example:
-	GT: "Paris is in France and capital of France."
-	Answer: "Paris is in France."
-	Output: ["Paris is capital of France"]
+		Example:
+		GT: "Paris is in France and capital of France."
+		Answer: "Paris is in France."
+		Output: ["Paris is capital of France"]
 
-	Example (no FN):
-	GT: "The process handles orders."
-	Answer: "Order processing is managed by the workflow."
-	Output: []  // Semantic coverage
-	""")
+		Example (no FN):
+		GT: "The process handles orders."
+		Answer: "Order processing is managed by the workflow."
+		Output: []  // Semantic coverage
+		""")
 	@UserMessage(USER_MESSAGE_PROMPT)
 	ArrayResponse extractFalseNegativeClaims(@V("groundTruth") String groundTruth, @V("actualAnswer") String actualAnswer);
 }

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answerrelevance/embedding/AnswerRelevanceEmbeddingBot.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answerrelevance/embedding/AnswerRelevanceEmbeddingBot.java
@@ -8,47 +8,47 @@ import dev.rage4j.evaluation.model.ArrayResponse;
 public interface AnswerRelevanceEmbeddingBot
 {
 	@SystemMessage("""
-You are a question generation model for evaluation purposes.
+		You are a question generation model for evaluation purposes.
 
-Your task is to generate short, specific user questions that are fully and directly answered by the provided answer text.
+		Your task is to generate short, specific user questions that are fully and directly answered by the provided answer text.
 
-The goal is to reconstruct the most likely original question that this answer is responding to.
-Generate multiple plausible phrasings of that same underlying question, not different side questions about different aspects of the answer.
+		The goal is to reconstruct the most likely original question that this answer is responding to.
+		Generate multiple plausible phrasings of that same underlying question, not different side questions about different aspects of the answer.
 
-Rules:
-- Use only information explicitly contained in the answer text.
-- Do not rely on outside knowledge, assumptions, or missing context.
-- Focus on the single most central question that the answer most directly answers.
-- Generate multiple plausible rephrasings of that same question.
-- The questions may be similar in meaning, but should differ naturally in wording.
-- Do not broaden the scope to secondary details or loosely related aspects of the answer.
-- Do not produce repeated questions with only trivial word swaps.
-- Do not produce yes/no questions unless the answer strongly implies that a yes/no question is the most direct original question.
-- Do not produce overly generic questions such as "What is this about?" or "What is being described?"
-- Keep each question concise, clear, and semantically meaningful.
-- Use the same language as the answer.
-- If the answer is empty, vague, non-committal, or does not contain enough information to infer a meaningful question, return an empty array [].
+		Rules:
+		- Use only information explicitly contained in the answer text.
+		- Do not rely on outside knowledge, assumptions, or missing context.
+		- Focus on the single most central question that the answer most directly answers.
+		- Generate multiple plausible rephrasings of that same question.
+		- The questions may be similar in meaning, but should differ naturally in wording.
+		- Do not broaden the scope to secondary details or loosely related aspects of the answer.
+		- Do not produce repeated questions with only trivial word swaps.
+		- Do not produce yes/no questions unless the answer strongly implies that a yes/no question is the most direct original question.
+		- Do not produce overly generic questions such as "What is this about?" or "What is being described?"
+		- Keep each question concise, clear, and semantically meaningful.
+		- Use the same language as the answer.
+		- If the answer is empty, vague, non-committal, or does not contain enough information to infer a meaningful question, return an empty array [].
 
-Output only a valid JSON array of strings.
-Do not include any explanation, numbering, markdown, or additional text.
-""")
+		Output only a valid JSON array of strings.
+		Do not include any explanation, numbering, markdown, or additional text.
+		""")
 	@UserMessage("""
-Generate exactly 5 short questions that represent plausible phrasings of the single most likely user question answered by the following answer text.
+		Generate exactly 5 short questions that represent plausible phrasings of the single most likely user question answered by the following answer text.
 
-Answer:
-"{{answer}}"
+		Answer:
+		"{{answer}}"
 
-Requirements:
-- Use only the information in the answer.
-- Focus on the most direct underlying question answered by the text.
-- Generate alternative phrasings of the same core question.
-- Do not turn secondary details into separate side questions.
-- Avoid trivial duplicates.
-- Do not use outside knowledge.
-- Keep the questions short and specific.
+		Requirements:
+		- Use only the information in the answer.
+		- Focus on the most direct underlying question answered by the text.
+		- Generate alternative phrasings of the same core question.
+		- Do not turn secondary details into separate side questions.
+		- Avoid trivial duplicates.
+		- Do not use outside knowledge.
+		- Keep the questions short and specific.
 
-Return only a JSON array of question strings.
-If the answer is empty, vague, or unanswerable, return [].
-""")
+		Return only a JSON array of question strings.
+		If the answer is empty, vague, or unanswerable, return [].
+		""")
 	ArrayResponse getGeneratedQuestions(@V("answer") String answer);
 }

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answerrelevance/embedding/AnswerRelevanceEmbeddingEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answerrelevance/embedding/AnswerRelevanceEmbeddingEvaluator.java
@@ -105,12 +105,14 @@ public class AnswerRelevanceEmbeddingEvaluator implements Evaluator
 	}
 
 	/**
-	 * Computes the mean cosine similarity between the original question and an array of generated questions. The similarities are calculated using a string similarity computer.
+	 * Computes the mean cosine similarity between the original question and an
+	 * array of generated questions. The similarities are calculated using a
+	 * string similarity computer.
 	 *
 	 * @param originalQuestion
-	 * 	The original question in the sample.
+	 *            The original question in the sample.
 	 * @param generatedQuestions
-	 * 	The questions generated from the answer.
+	 *            The questions generated from the answer.
 	 * @return The mean cosine similarity score.
 	 */
 	private double getMeanCosineSimilarity(String originalQuestion, String[] generatedQuestions)

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answerrelevance/llm/AnswerRelevanceLlmEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/answerrelevance/llm/AnswerRelevanceLlmEvaluator.java
@@ -25,10 +25,15 @@ public class AnswerRelevanceLlmEvaluator implements Evaluator
 	}
 
 	/**
-	 * Constructs a new {@code AnswerRelevanceLlmEvaluator} with a provided {@code AnswerRelevanceLlmBot}. This constructor is useful for testing purposes, where the {@code AnswerRelevanceLlmBot} can be mocked and directly injected, bypassing the need to create it via {@code AiServices}.
+	 * Constructs a new {@code AnswerRelevanceLlmEvaluator} with a provided
+	 * {@code AnswerRelevanceLlmBot}. This constructor is useful for testing
+	 * purposes, where the {@code AnswerRelevanceLlmBot} can be mocked and
+	 * directly injected, bypassing the need to create it via
+	 * {@code AiServices}.
 	 *
 	 * @param bot
-	 * 	The {@code AnswerRelevanceLlmBot} to be used for generating the relevance score.
+	 *            The {@code AnswerRelevanceLlmBot} to be used for generating
+	 *            the relevance score.
 	 */
 	public AnswerRelevanceLlmEvaluator(AnswerRelevanceLlmBot bot)
 	{
@@ -36,13 +41,16 @@ public class AnswerRelevanceLlmEvaluator implements Evaluator
 	}
 
 	/**
-	 * Evaluates the given sample according to a specific metric and returns the result as an {@code Evaluation}.
+	 * Evaluates the given sample according to a specific metric and returns the
+	 * result as an {@code Evaluation}.
 	 *
 	 * @param sample
-	 * 	The sample containing data (such as context and answer) to be evaluated.
-	 * @return An {@code Evaluation} object representing the metric name and its calculated value.
+	 *            The sample containing data (such as context and answer) to be
+	 *            evaluated.
+	 * @return An {@code Evaluation} object representing the metric name and its
+	 *         calculated value.
 	 * @throws IllegalArgumentException
-	 * 	if the sample is invalid or cannot be evaluated.
+	 *             if the sample is invalid or cannot be evaluated.
 	 */
 	@Override
 	public Evaluation evaluate(Sample sample)

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/embedding/ContextRelevanceEmbeddingEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/embedding/ContextRelevanceEmbeddingEvaluator.java
@@ -45,14 +45,14 @@ public class ContextRelevanceEmbeddingEvaluator implements Evaluator
 		var similarityScores = stringSimilarityBatchComputer.apply(question, chunks);
 		if (similarityScores == null || similarityScores.isEmpty())
 		{
-			LOG.warn("stringSimilarityBatchComputer returned {} for {} chunks; returning score 0.0", 
-					(similarityScores == null ? "null" : "an empty list"), chunks.size());
+			LOG.warn("stringSimilarityBatchComputer returned {} for {} chunks; returning score 0.0",
+				(similarityScores == null ? "null" : "an empty list"), chunks.size());
 			return new Evaluation(METRIC_NAME, 0.0);
 		}
 		if (similarityScores.size() != chunks.size())
 		{
 			LOG.warn("stringSimilarityBatchComputer returned {} similarity scores for {} chunks; proceeding with average over returned scores",
-					similarityScores.size(), chunks.size());
+				similarityScores.size(), chunks.size());
 		}
 		double sumSimilarity = similarityScores.stream().mapToDouble(Double::doubleValue).sum();
 		double result = sumSimilarity / similarityScores.size();

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmBot.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmBot.java
@@ -1,21 +1,19 @@
 package dev.rage4j.evaluation.contextrelevance.llm;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 
+import java.util.List;
+
 public interface ContextRelevanceLlmBot
 {
 	@SystemMessage("""
-		You are evaluating the relevance of this context concerning the given question.
+		You are evaluating the relevance of a context concerning a given question. \
+		The context may also include one or more attached images — if any are present, take their visual content into account.
 
-		context:
-		{{context}}
-
-		Question:
-		{{question}}
-
-		Score how well the context addresses the question.
+		Score how well the context (text and any attached images) addresses the question.
 
 		0 = completely irrelevant
 		1 = partially relevant
@@ -24,6 +22,16 @@ public interface ContextRelevanceLlmBot
 
 		Return exactly one integer: 0, 1, 2, or 3. Output must contain only that single digit and nothing else.
 		""")
-	@UserMessage("Evaluate the context.")
-	String generateScore(@V("question") String question, @V("context") String context);
+	@UserMessage("""
+		context:
+		{{context}}
+
+		Question:
+		{{question}}
+
+		Evaluate the context.""")
+	String generateScore(
+		@UserMessage List<ImageContent> images,
+		@V("question") String question,
+		@V("context") String context);
 }

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluator.java
@@ -16,11 +16,11 @@ import java.util.List;
 import static dev.rage4j.util.ScoreParser.parseScore;
 
 /**
- * Evaluates how well the context of a {@link Sample} addresses its question.
- * If the sample carries images and the evaluator was constructed against a
+ * Evaluates how well the context of a {@link Sample} addresses its question. If
+ * the sample carries images and the evaluator was constructed against a
  * vision-capable {@link ChatModel} (i.e. {@code supportsVision} is
- * {@code true}), the images are forwarded to the bot together with the
- * textual context. When images are present but vision was not enabled, an
+ * {@code true}), the images are forwarded to the bot together with the textual
+ * context. When images are present but vision was not enabled, an
  * {@link UnsupportedOperationException} is thrown.
  */
 public class ContextRelevanceLlmEvaluator implements Evaluator

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluator.java
@@ -1,15 +1,28 @@
 package dev.rage4j.evaluation.contextrelevance.llm;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import dev.rage4j.evaluation.Evaluation;
 import dev.rage4j.evaluation.Evaluator;
+import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
+import dev.rage4j.util.VisionModelGuard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 import static dev.rage4j.util.ScoreParser.parseScore;
 
+/**
+ * Evaluates how well the context of a {@link Sample} addresses its question.
+ * If the sample carries images and the evaluator was constructed against a
+ * vision-capable {@link ChatModel} (i.e. {@code supportsVision} is
+ * {@code true}), the images are forwarded to the bot together with the
+ * textual context. When images are present but vision was not enabled, an
+ * {@link UnsupportedOperationException} is thrown.
+ */
 public class ContextRelevanceLlmEvaluator implements Evaluator
 {
 
@@ -19,28 +32,42 @@ public class ContextRelevanceLlmEvaluator implements Evaluator
 	private static final Logger LOG = LoggerFactory.getLogger(ContextRelevanceLlmEvaluator.class);
 
 	private final ContextRelevanceLlmBot bot;
+	private final boolean supportsVision;
 
 	public ContextRelevanceLlmEvaluator(ChatModel judgeModel)
 	{
-		bot = AiServices.create(ContextRelevanceLlmBot.class, judgeModel);
+		this(judgeModel, false);
+	}
+
+	public ContextRelevanceLlmEvaluator(ChatModel judgeModel, boolean supportsVision)
+	{
+		this.bot = AiServices.create(ContextRelevanceLlmBot.class, judgeModel);
+		this.supportsVision = supportsVision;
 	}
 
 	public ContextRelevanceLlmEvaluator(ContextRelevanceLlmBot bot)
 	{
+		this(bot, false);
+	}
+
+	public ContextRelevanceLlmEvaluator(ContextRelevanceLlmBot bot, boolean supportsVision)
+	{
 		this.bot = bot;
+		this.supportsVision = supportsVision;
 	}
 
 	/**
-	 * Evaluates the given sample according to a specific metric and returns the
-	 * result as an {@code Evaluation}.
+	 * Evaluates the given sample according to the context-relevance metric and
+	 * returns the result as an {@code Evaluation}.
 	 *
 	 * @param sample
-	 *            The sample containing data (such as question and context) to be
-	 *            evaluated.
-	 * @return An {@code Evaluation} object representing the metric name and its
-	 *         calculated value.
+	 *            The sample containing question, context and optionally images.
+	 * @return An {@code Evaluation} object with the metric name and value.
 	 * @throws IllegalArgumentException
-	 *             if the sample is invalid or cannot be evaluated.
+	 *             if the sample lacks a context or a question.
+	 * @throws UnsupportedOperationException
+	 *             if the sample carries images but the evaluator was not
+	 *             configured for vision.
 	 */
 	@Override
 	public Evaluation evaluate(Sample sample)
@@ -53,19 +80,26 @@ public class ContextRelevanceLlmEvaluator implements Evaluator
 		{
 			throw new IllegalArgumentException("Sample must have a question for Context Relevance LLM evaluation");
 		}
+		VisionModelGuard.requireVisionSupportIfImagesPresent(sample, supportsVision, METRIC_NAME);
 
 		String question = sample.getQuestion();
 		String context = sample.getContext();
+		List<ImageContent> images = mapImages(sample);
 		LOG.info("Evaluating new sample");
 		LOG.info("Question: {}", question);
 		LOG.info("Context: {}", context);
+		if (!images.isEmpty())
+		{
+			LOG.info("Forwarding {} image(s) to context-relevance bot", images.size());
+		}
 
-		if (context.isBlank())
+		// Without text context AND without images, there is nothing to score.
+		if (context.isBlank() && images.isEmpty())
 		{
 			return new Evaluation(METRIC_NAME, 0.0);
 		}
 
-		String scoreRaw = bot.generateScore(question, context);
+		String scoreRaw = bot.generateScore(images, question, context);
 
 		int score = parseScore(scoreRaw);
 		LOG.info("Raw score from LLM: {}", score);
@@ -74,6 +108,17 @@ public class ContextRelevanceLlmEvaluator implements Evaluator
 		LOG.info("Evaluation result: {}", result);
 
 		return new Evaluation(METRIC_NAME, result);
+	}
+
+	private static List<ImageContent> mapImages(Sample sample)
+	{
+		if (!sample.hasImages())
+		{
+			return List.of();
+		}
+		return sample.getImages().stream()
+			.map(Rage4jImage::toImageContent)
+			.toList();
 	}
 
 	private static double normalize(double score)

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessBot.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessBot.java
@@ -1,9 +1,12 @@
 package dev.rage4j.evaluation.faithfulness;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import dev.rage4j.evaluation.model.ArrayResponse;
+
+import java.util.List;
 
 public interface FaithfulnessBot
 {
@@ -12,13 +15,18 @@ public interface FaithfulnessBot
 	ArrayResponse extractClaims(@V("text") String text);
 
 	@SystemMessage("""
-		You are a fact checker LLM. You are provided with a context and a claim. \
-		Determine whether the claim can be inferred from the context. \
+		You are a fact checker LLM. You are provided with a context, a claim, \
+		and optionally one or more images that are part of the context. \
+		Determine whether the claim can be inferred from the context (and from the images, if present). \
 		A claim can be inferred if it follows directly from the context OR if it can be derived through reasoning, \
 		including: arithmetic calculations (e.g. summing numbers, counting items), \
 		parsing structured data formats such as JSON or XML, \
+		visual analysis of any provided images, \
 		or logical implications of the context content. \
 		Answer only true or false.""")
-	@UserMessage("Can the following claim be inferred from the context? Claim: '{{claim}}' Context: '{{info}}'")
-	Boolean canBeInferred(@V("info") String info, @V("claim") String claim);
+	@UserMessage("Can the following claim be inferred from the context? Claim: '{{claim}}' Context: '{{context}}'")
+	Boolean canBeInferred(
+		@UserMessage List<ImageContent> images,
+		@V("claim") String claim,
+		@V("context") String context);
 }

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluator.java
@@ -74,9 +74,9 @@ public class FaithfulnessEvaluator implements Evaluator
 
 	/**
 	 * Constructs a new text-only {@code FaithfulnessEvaluator} with a provided
-	 * {@code FaithfulnessBot}. This constructor is useful for testing
-	 * purposes, where the bot can be mocked and directly injected, bypassing
-	 * the need to create it via {@code AiServices}.
+	 * {@code FaithfulnessBot}. This constructor is useful for testing purposes,
+	 * where the bot can be mocked and directly injected, bypassing the need to
+	 * create it via {@code AiServices}.
 	 *
 	 * @param bot
 	 *            The {@code FaithfulnessBot} to be used for evaluating the
@@ -106,8 +106,8 @@ public class FaithfulnessEvaluator implements Evaluator
 
 	/**
 	 * Evaluates the faithfulness of a given answer by extracting claims from
-	 * the answer and checking if they can be inferred from the provided
-	 * context (and, if available and supported, images).
+	 * the answer and checking if they can be inferred from the provided context
+	 * (and, if available and supported, images).
 	 *
 	 * @param sample
 	 *            The sample containing the answer to evaluate and the context

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluator.java
@@ -1,15 +1,19 @@
 package dev.rage4j.evaluation.faithfulness;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import dev.rage4j.evaluation.Evaluation;
 import dev.rage4j.evaluation.Evaluator;
+import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
+import dev.rage4j.util.VisionModelGuard;
 import org.apache.commons.math3.analysis.function.Divide;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * The {@code FaithfulnessEvaluator} class provides a mechanism to evaluate the
@@ -20,16 +24,25 @@ import java.util.Arrays;
  * <p>
  * The metric used is the fraction of claims that can be inferred from the
  * context, labeled as "Faithfulness."
+ * <p>
+ * If the {@link Sample} carries images and the evaluator was constructed
+ * against a vision-capable {@link ChatModel} (i.e. {@code supportsVision} is
+ * {@code true}), the images are forwarded to the bot together with the textual
+ * context. When images are present but the evaluator was not configured for
+ * vision, an {@link UnsupportedOperationException} is thrown.
  */
 public class FaithfulnessEvaluator implements Evaluator
 {
 	private static final String METRIC_NAME = "Faithfulness";
 	private static final Logger LOG = LoggerFactory.getLogger(FaithfulnessEvaluator.class);
 	private final FaithfulnessBot bot;
+	private final boolean supportsVision;
 
 	/**
-	 * Constructs a new {@code FaithfulnessEvaluator} that evaluates
-	 * faithfulness using a specified language model.
+	 * Constructs a new text-only {@code FaithfulnessEvaluator}. Samples that
+	 * carry images will cause an {@link UnsupportedOperationException} at
+	 * evaluation time. Use {@link #FaithfulnessEvaluator(ChatModel, boolean)}
+	 * to opt into vision.
 	 *
 	 * @param model
 	 *            The language model used to power the {@code FaithfulnessBot}
@@ -37,14 +50,33 @@ public class FaithfulnessEvaluator implements Evaluator
 	 */
 	public FaithfulnessEvaluator(ChatModel model)
 	{
-		bot = AiServices.create(FaithfulnessBot.class, model);
+		this(model, false);
 	}
 
 	/**
-	 * Constructs a new {@code FaithfulnessEvaluator} with a provided
-	 * {@code FaithfulnessBot}. This constructor is useful for testing purposes,
-	 * where the {@code FaithfulnessBot} can be mocked and directly injected,
-	 * bypassing the need to create it via {@code AiServices}.
+	 * Constructs a new {@code FaithfulnessEvaluator} that may optionally
+	 * forward images from the {@link Sample} to the underlying bot.
+	 *
+	 * @param model
+	 *            The language model used to power the {@code FaithfulnessBot}.
+	 *            Must be vision-capable when {@code supportsVision} is
+	 *            {@code true}.
+	 * @param supportsVision
+	 *            Whether the supplied {@code ChatModel} can handle multimodal
+	 *            input. When {@code false}, samples carrying images cause an
+	 *            {@link UnsupportedOperationException} at evaluation time.
+	 */
+	public FaithfulnessEvaluator(ChatModel model, boolean supportsVision)
+	{
+		this.bot = AiServices.create(FaithfulnessBot.class, model);
+		this.supportsVision = supportsVision;
+	}
+
+	/**
+	 * Constructs a new text-only {@code FaithfulnessEvaluator} with a provided
+	 * {@code FaithfulnessBot}. This constructor is useful for testing
+	 * purposes, where the bot can be mocked and directly injected, bypassing
+	 * the need to create it via {@code AiServices}.
 	 *
 	 * @param bot
 	 *            The {@code FaithfulnessBot} to be used for evaluating the
@@ -52,13 +84,30 @@ public class FaithfulnessEvaluator implements Evaluator
 	 */
 	public FaithfulnessEvaluator(FaithfulnessBot bot)
 	{
+		this(bot, false);
+	}
+
+	/**
+	 * Constructs a new {@code FaithfulnessEvaluator} with a provided
+	 * {@code FaithfulnessBot} and an explicit vision-support flag. Useful for
+	 * testing the multimodal code path with a mocked bot.
+	 *
+	 * @param bot
+	 *            The {@code FaithfulnessBot} to be used for evaluating the
+	 *            faithfulness of a sample.
+	 * @param supportsVision
+	 *            Whether the bot's underlying model is vision-capable.
+	 */
+	public FaithfulnessEvaluator(FaithfulnessBot bot, boolean supportsVision)
+	{
 		this.bot = bot;
+		this.supportsVision = supportsVision;
 	}
 
 	/**
 	 * Evaluates the faithfulness of a given answer by extracting claims from
 	 * the answer and checking if they can be inferred from the provided
-	 * context.
+	 * context (and, if available and supported, images).
 	 *
 	 * @param sample
 	 *            The sample containing the answer to evaluate and the context
@@ -67,6 +116,9 @@ public class FaithfulnessEvaluator implements Evaluator
 	 *         metric and its computed score.
 	 * @throws IllegalArgumentException
 	 *             if the sample does not contain a valid answer or context.
+	 * @throws UnsupportedOperationException
+	 *             if the sample carries images but the evaluator was not
+	 *             configured for vision.
 	 */
 	public Evaluation evaluate(Sample sample)
 	{
@@ -78,16 +130,22 @@ public class FaithfulnessEvaluator implements Evaluator
 		{
 			throw new IllegalArgumentException("Sample must have a context for Faithfulness evaluation");
 		}
+		VisionModelGuard.requireVisionSupportIfImagesPresent(sample, supportsVision, METRIC_NAME);
 
 		LOG.info("Evaluating new sample");
 		String answer = sample.getAnswer();
 		LOG.info("Answer: {}", answer);
 		String context = sample.getContext();
 		LOG.info("Context: {}", context);
+		List<ImageContent> images = mapImages(sample);
+		if (!images.isEmpty())
+		{
+			LOG.info("Forwarding {} image(s) to faithfulness bot", images.size());
+		}
 		String[] answerClaims = bot.extractClaims(answer).getItems();
 		LOG.info("Extracted claims: {}", (Object)answerClaims);
 
-		double inferredClaimsCount = getInferredClaimsCount(context, answerClaims);
+		double inferredClaimsCount = getInferredClaimsCount(context, answerClaims, images);
 		LOG.info("Inferred claims count: {}", inferredClaimsCount);
 		if (inferredClaimsCount == 0.0)
 		{
@@ -99,20 +157,25 @@ public class FaithfulnessEvaluator implements Evaluator
 		return new Evaluation(METRIC_NAME, inferredToAllFraction);
 	}
 
+	private static List<ImageContent> mapImages(Sample sample)
+	{
+		if (!sample.hasImages())
+		{
+			return List.of();
+		}
+		return sample.getImages().stream()
+			.map(Rage4jImage::toImageContent)
+			.toList();
+	}
+
 	/**
 	 * Counts the number of claims from the answer that can be inferred from the
-	 * given context.
-	 *
-	 * @param context
-	 *            The context text to evaluate against.
-	 * @param claims
-	 *            The claims extracted from the answer.
-	 * @return The number of claims that can be inferred from the context.
+	 * given context (and images, when present).
 	 */
-	private long getInferredClaimsCount(String context, String[] claims)
+	private long getInferredClaimsCount(String context, String[] claims, List<ImageContent> images)
 	{
 		return Arrays.stream(claims)
-			.filter(claim -> bot.canBeInferred(context, claim))
+			.filter(claim -> bot.canBeInferred(images, claim, context))
 			.count();
 	}
 }

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/EvaluationAggregation.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/EvaluationAggregation.java
@@ -71,19 +71,20 @@ public class EvaluationAggregation extends HashMap<String, Double>
 
 	/**
 	 * Returns the sample as a map for JSON serialization. Only non-null fields
-	 * of the sample are included.
+	 * of the sample are included. Images, when present, are serialised as a
+	 * list of their names – the actual image bytes are never persisted.
 	 *
-	 * @return A map representation of the sample, or null if no sample is
-	 *         associated.
+	 * @return A map representation of the sample, or an empty map if no sample
+	 *         is associated.
 	 */
 	@JsonProperty("sample")
-	public Map<String, String> sampleMap()
+	public Map<String, Object> sampleMap()
 	{
 		if (sample == null)
 		{
 			return Collections.emptyMap();
 		}
-		Map<String, String> map = new LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		if (sample.hasQuestion())
 		{
 			map.put("question", sample.getQuestion());
@@ -99,6 +100,12 @@ public class EvaluationAggregation extends HashMap<String, Double>
 		if (sample.hasContext())
 		{
 			map.put("context", sample.getContext());
+		}
+		if (sample.hasImages())
+		{
+			map.put("images", sample.getImages().stream()
+				.map(Rage4jImage::getName)
+				.toList());
 		}
 		return map;
 	}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Rage4jImage.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Rage4jImage.java
@@ -1,0 +1,226 @@
+package dev.rage4j.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import dev.langchain4j.data.message.ImageContent;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Represents an image attached to a {@link Sample} that should be passed
+ * alongside the textual context to vision-capable evaluation LLMs.
+ * <p>
+ * An instance always has a {@code name} (used for logging and persistence)
+ * and either inline data ({@code data} + {@code mimeType}) <em>or</em> a
+ * remote {@code url}. The image bytes are never serialised to disk by the
+ * persist module – only the metadata is.
+ */
+public final class Rage4jImage implements Serializable
+{
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	private final String name;
+	private final String mimeType;
+	private final URI url;
+
+	@JsonIgnore
+	private final transient byte[] data;
+
+	private Rage4jImage(String name, String mimeType, byte[] data, URI url)
+	{
+		this.name = Objects.requireNonNull(name, "name");
+		this.mimeType = mimeType;
+		this.data = data;
+		this.url = url;
+	}
+
+	/**
+	 * Loads an image from a local file. Name and MIME type are derived from
+	 * the file path.
+	 */
+	public static Rage4jImage fromPath(Path path)
+	{
+		Objects.requireNonNull(path, "path");
+		String fileName = path.getFileName().toString();
+		String mime = guessMimeFromFileName(fileName);
+		byte[] bytes;
+		try
+		{
+			bytes = Files.readAllBytes(path);
+		}
+		catch (IOException e)
+		{
+			throw new IllegalArgumentException("Could not read image file: " + path, e);
+		}
+		return new Rage4jImage(fileName, mime, bytes, null);
+	}
+
+	/**
+	 * Loads an image from a local file with an explicit name override.
+	 */
+	public static Rage4jImage fromPath(Path path, String name)
+	{
+		Objects.requireNonNull(path, "path");
+		Objects.requireNonNull(name, "name");
+		byte[] bytes;
+		try
+		{
+			bytes = Files.readAllBytes(path);
+		}
+		catch (IOException e)
+		{
+			throw new IllegalArgumentException("Could not read image file: " + path, e);
+		}
+		return new Rage4jImage(name, guessMimeFromFileName(name), bytes, null);
+	}
+
+	/**
+	 * Builds an image from raw bytes plus the explicit MIME type and a name.
+	 */
+	public static Rage4jImage fromBytes(byte[] data, String mimeType, String name)
+	{
+		Objects.requireNonNull(data, "data");
+		Objects.requireNonNull(mimeType, "mimeType");
+		Objects.requireNonNull(name, "name");
+		return new Rage4jImage(name, mimeType, data.clone(), null);
+	}
+
+	/**
+	 * References an image by URL. The name defaults to the last URL segment.
+	 */
+	public static Rage4jImage fromUrl(String url)
+	{
+		Objects.requireNonNull(url, "url");
+		URI uri = URI.create(url);
+		String name = deriveNameFromUri(uri);
+		return new Rage4jImage(name, guessMimeFromFileName(name), null, uri);
+	}
+
+	/**
+	 * References an image by URL with an explicit name override.
+	 */
+	public static Rage4jImage fromUrl(String url, String name)
+	{
+		Objects.requireNonNull(url, "url");
+		Objects.requireNonNull(name, "name");
+		URI uri = URI.create(url);
+		return new Rage4jImage(name, guessMimeFromFileName(name), null, uri);
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public String getMimeType()
+	{
+		return mimeType;
+	}
+
+	public URI getUrl()
+	{
+		return url;
+	}
+
+	@JsonIgnore
+	public byte[] getData()
+	{
+		return data == null ? null : data.clone();
+	}
+
+	@JsonIgnore
+	public boolean hasInlineData()
+	{
+		return data != null;
+	}
+
+	/**
+	 * Maps this image to a LangChain4j {@link ImageContent} suitable for
+	 * sending in a multimodal {@code UserMessage}.
+	 */
+	public ImageContent toImageContent()
+	{
+		if (url != null)
+		{
+			return ImageContent.from(url);
+		}
+		String base64 = java.util.Base64.getEncoder().encodeToString(data);
+		return ImageContent.from(base64, mimeType);
+	}
+
+	private static String deriveNameFromUri(URI uri)
+	{
+		String path = uri.getPath();
+		if (path == null || path.isBlank() || path.equals("/"))
+		{
+			return uri.toString();
+		}
+		int slash = path.lastIndexOf('/');
+		String segment = slash >= 0 ? path.substring(slash + 1) : path;
+		return segment.isBlank() ? uri.toString() : segment;
+	}
+
+	private static String guessMimeFromFileName(String name)
+	{
+		String lower = name.toLowerCase();
+		if (lower.endsWith(".png"))
+		{
+			return "image/png";
+		}
+		if (lower.endsWith(".jpg") || lower.endsWith(".jpeg"))
+		{
+			return "image/jpeg";
+		}
+		if (lower.endsWith(".gif"))
+		{
+			return "image/gif";
+		}
+		if (lower.endsWith(".webp"))
+		{
+			return "image/webp";
+		}
+		if (lower.endsWith(".bmp"))
+		{
+			return "image/bmp";
+		}
+		return "application/octet-stream";
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (o == null || getClass() != o.getClass())
+		{
+			return false;
+		}
+		Rage4jImage that = (Rage4jImage)o;
+		return Objects.equals(name, that.name)
+			&& Objects.equals(mimeType, that.mimeType)
+			&& Objects.equals(url, that.url)
+			&& java.util.Arrays.equals(data, that.data);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		int result = Objects.hash(name, mimeType, url);
+		result = 31 * result + java.util.Arrays.hashCode(data);
+		return result;
+	}
+
+	@Override
+	public String toString()
+	{
+		return "Rage4jImage{name='" + name + "', mimeType='" + mimeType + "', url=" + url + ", inline=" + hasInlineData() + "}";
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Rage4jImage.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Rage4jImage.java
@@ -15,10 +15,10 @@ import java.util.Objects;
  * Represents an image attached to a {@link Sample} that should be passed
  * alongside the textual context to vision-capable evaluation LLMs.
  * <p>
- * An instance always has a {@code name} (used for logging and persistence)
- * and either inline data ({@code data} + {@code mimeType}) <em>or</em> a
- * remote {@code url}. The image bytes are never serialised to disk by the
- * persist module – only the metadata is.
+ * An instance always has a {@code name} (used for logging and persistence) and
+ * either inline data ({@code data} + {@code mimeType}) <em>or</em> a remote
+ * {@code url}. The image bytes are never serialised to disk by the persist
+ * module – only the metadata is.
  */
 public final class Rage4jImage implements Serializable
 {
@@ -41,8 +41,8 @@ public final class Rage4jImage implements Serializable
 	}
 
 	/**
-	 * Loads an image from a local file. Name and MIME type are derived from
-	 * the file path.
+	 * Loads an image from a local file. Name and MIME type are derived from the
+	 * file path.
 	 */
 	public static Rage4jImage fromPath(Path path)
 	{

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Sample.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Sample.java
@@ -2,6 +2,9 @@ package dev.rage4j.model;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -22,6 +25,7 @@ public class Sample implements Serializable
 	protected String answer;
 	protected String groundTruth;
 	protected String context;
+	protected List<Rage4jImage> images;
 
 	/**
 	 * Private constructor to initialize a {@code Sample} object using a
@@ -37,6 +41,7 @@ public class Sample implements Serializable
 		this.answer = builder.answer;
 		this.groundTruth = builder.groundTruth;
 		this.context = builder.context;
+		this.images = builder.images == null ? null : List.copyOf(builder.images);
 	}
 
 	/**
@@ -111,6 +116,25 @@ public class Sample implements Serializable
 		return context != null;
 	}
 
+	/**
+	 * Returns the images attached to the sample. The list is unmodifiable and
+	 * never {@code null}.
+	 *
+	 * @return The (possibly empty) list of images.
+	 */
+	public List<Rage4jImage> getImages()
+	{
+		return images == null ? Collections.emptyList() : images;
+	}
+
+	/**
+	 * @return whether the sample has at least one image attached.
+	 */
+	public boolean hasImages()
+	{
+		return images != null && !images.isEmpty();
+	}
+
 	@Override
 	public boolean equals(Object o)
 	{
@@ -126,13 +150,14 @@ public class Sample implements Serializable
 		return Objects.equals(question, sample.question)
 			&& Objects.equals(answer, sample.answer)
 			&& Objects.equals(groundTruth, sample.groundTruth)
-			&& Objects.equals(context, sample.context);
+			&& Objects.equals(context, sample.context)
+			&& Objects.equals(images, sample.images);
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(question, answer, groundTruth, context);
+		return Objects.hash(question, answer, groundTruth, context, images);
 	}
 
 	/**
@@ -157,6 +182,7 @@ public class Sample implements Serializable
 		private String answer;
 		private String groundTruth;
 		private String context;
+		private List<Rage4jImage> images;
 
 		/**
 		 * Sets the question for the {@code Sample}.
@@ -207,6 +233,40 @@ public class Sample implements Serializable
 		public SampleBuilder withContext(String context)
 		{
 			this.context = context;
+			return this;
+		}
+
+		/**
+		 * Adds a single image to the {@code Sample}. May be called multiple
+		 * times to attach several images. Images are passed to vision-capable
+		 * evaluators alongside the textual context.
+		 *
+		 * @param image
+		 *            The image to add.
+		 * @return The current instance of {@code SampleBuilder}.
+		 */
+		public SampleBuilder withImage(Rage4jImage image)
+		{
+			Objects.requireNonNull(image, "image");
+			if (this.images == null)
+			{
+				this.images = new ArrayList<>();
+			}
+			this.images.add(image);
+			return this;
+		}
+
+		/**
+		 * Replaces the image list of the {@code Sample}. Pass {@code null} or
+		 * an empty list to clear it.
+		 *
+		 * @param images
+		 *            The list of images.
+		 * @return The current instance of {@code SampleBuilder}.
+		 */
+		public SampleBuilder withImages(List<Rage4jImage> images)
+		{
+			this.images = images == null ? null : new ArrayList<>(images);
 			return this;
 		}
 

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/util/VisionModelGuard.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/util/VisionModelGuard.java
@@ -1,0 +1,48 @@
+package dev.rage4j.util;
+
+import dev.rage4j.model.Sample;
+
+/**
+ * Centralised pre-flight check for image-bearing samples. Evaluators that can
+ * forward images to a multimodal LLM call this guard before any API request
+ * goes out.
+ * <p>
+ * LangChain4j 1.0.x does not expose a {@code Capability.VISION} flag on
+ * {@code ChatModel}, so vision support cannot be detected from the model
+ * itself. The caller is therefore expected to declare it explicitly when
+ * constructing the evaluator. If a sample carries images but the evaluator
+ * was not opted into vision, this guard fails fast with an
+ * {@link UnsupportedOperationException} that names the offending evaluator.
+ */
+public final class VisionModelGuard
+{
+	private VisionModelGuard()
+	{
+	}
+
+	/**
+	 * Throws if {@code sample} carries images but {@code supportsVision} is
+	 * {@code false}.
+	 *
+	 * @param sample
+	 *            The sample about to be evaluated.
+	 * @param supportsVision
+	 *            Whether the evaluator was constructed against a
+	 *            vision-capable {@code ChatModel}.
+	 * @param evaluatorName
+	 *            Short name of the evaluator (e.g. {@code "Faithfulness"}),
+	 *            used to produce a helpful error message.
+	 */
+	public static void requireVisionSupportIfImagesPresent(Sample sample, boolean supportsVision, String evaluatorName)
+	{
+		if (sample.hasImages() && !supportsVision)
+		{
+			throw new UnsupportedOperationException(
+				evaluatorName
+					+ " evaluator received a Sample with "
+					+ sample.getImages().size()
+					+ " image(s) but was not configured for vision. "
+					+ "Pass a vision-capable ChatModel (e.g. gpt-4o) and use the constructor variant that takes supportsVision=true.");
+		}
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/util/VisionModelGuard.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/util/VisionModelGuard.java
@@ -10,8 +10,8 @@ import dev.rage4j.model.Sample;
  * LangChain4j 1.0.x does not expose a {@code Capability.VISION} flag on
  * {@code ChatModel}, so vision support cannot be detected from the model
  * itself. The caller is therefore expected to declare it explicitly when
- * constructing the evaluator. If a sample carries images but the evaluator
- * was not opted into vision, this guard fails fast with an
+ * constructing the evaluator. If a sample carries images but the evaluator was
+ * not opted into vision, this guard fails fast with an
  * {@link UnsupportedOperationException} that names the offending evaluator.
  */
 public final class VisionModelGuard
@@ -27,8 +27,8 @@ public final class VisionModelGuard
 	 * @param sample
 	 *            The sample about to be evaluated.
 	 * @param supportsVision
-	 *            Whether the evaluator was constructed against a
-	 *            vision-capable {@code ChatModel}.
+	 *            Whether the evaluator was constructed against a vision-capable
+	 *            {@code ChatModel}.
 	 * @param evaluatorName
 	 *            Short name of the evaluator (e.g. {@code "Faithfulness"}),
 	 *            used to produce a helpful error message.

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/answercorrectness/AnswerCorrectnessEvaluatorIntegrationTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/answercorrectness/AnswerCorrectnessEvaluatorIntegrationTest.java
@@ -25,11 +25,11 @@ class AnswerCorrectnessEvaluatorIntegrationTest
 	private static final String ANSWER_WITH_FALSE_NEGATIVE = "Paris is the capital.";
 
 	// Tests where more than one claim is extracted:
-	// Question could be here: "Which city is the capital of France and which is the largest city in France?"
+	// Question could be here: "Which city is the capital of France and which is
+	// the largest city in France?"
 	private static final String GROUND_TRUTH_ENHANCED = "Paris is the capital and the largest city in France.";
 	private static final String ANSWER_WITH_FALSE_POSITIVE_ENHANCED = "Paris is the capital of Germany and France and the largest city in France.";
 	private static final String ANSWER_WITH_FALSE_NEGATIVE_ENHANCED = "Paris is the capital of France.";
-
 
 	private static final String QUESTION = "What is the capital of France?";
 
@@ -76,8 +76,10 @@ class AnswerCorrectnessEvaluatorIntegrationTest
 		Evaluation result = evaluator.evaluate(sample);
 
 		assertEquals("Answer correctness", result.getName());
-		// Expect a score of 0.0 because the answer contradicts the ground truth,
-		// leading to no true positives (and both a false positive and a false negative).
+		// Expect a score of 0.0 because the answer contradicts the ground
+		// truth,
+		// leading to no true positives (and both a false positive and a false
+		// negative).
 		assertEquals(0.0, result.getValue(), 0.1);
 	}
 
@@ -86,15 +88,16 @@ class AnswerCorrectnessEvaluatorIntegrationTest
 	void testEvaluateWithFalsePositiveEnhanced()
 	{
 		Sample sample = Sample.builder()
-				.withGroundTruth(GROUND_TRUTH_ENHANCED)
-				.withAnswer(ANSWER_WITH_FALSE_POSITIVE_ENHANCED)
-				.build();
+			.withGroundTruth(GROUND_TRUTH_ENHANCED)
+			.withAnswer(ANSWER_WITH_FALSE_POSITIVE_ENHANCED)
+			.build();
 
 		Evaluation result = evaluator.evaluate(sample);
 
 		assertEquals("Answer correctness", result.getName());
 		// Expect a value less than 1.0 due to
-		// - 2 TP: "Paris is the capital of France" and "Paris is the largest City in France"
+		// - 2 TP: "Paris is the capital of France" and "Paris is the largest
+		// City in France"
 		// - 1 FP: "Paris is the capital of Germany"
 		assertEquals(0.7, result.getValue(), 0.1);
 	}
@@ -112,11 +115,14 @@ class AnswerCorrectnessEvaluatorIntegrationTest
 
 		assertEquals("Answer correctness", result.getName());
 		// Expect a value of 0.0 due to:
-		// - No TP: because Answer and/or GT is too short see testEvaluateWithFalseNegativeEnhanced() -> could be 1 TP or 0 TP
+		// - No TP: because Answer and/or GT is too short see
+		// testEvaluateWithFalseNegativeEnhanced() -> could be 1 TP or 0 TP
 		// - FN: "...of France"
-		var success =
-				result.getValue() >= 0 && result.getValue() <= 0.1 || // no TP extracted
-				result.getValue() >= 0.6 && result.getValue() <= 0.7; // TP extracted
+		var success = result.getValue() >= 0 && result.getValue() <= 0.1 || // no
+																			// TP
+																			// extracted
+			result.getValue() >= 0.6 && result.getValue() <= 0.7; // TP
+																	// extracted
 		assertTrue(success);
 	}
 
@@ -125,9 +131,9 @@ class AnswerCorrectnessEvaluatorIntegrationTest
 	void testEvaluateWithFalseNegativeEnhanced()
 	{
 		Sample sample = Sample.builder()
-				.withGroundTruth(GROUND_TRUTH_ENHANCED)
-				.withAnswer(ANSWER_WITH_FALSE_NEGATIVE_ENHANCED)
-				.build();
+			.withGroundTruth(GROUND_TRUTH_ENHANCED)
+			.withAnswer(ANSWER_WITH_FALSE_NEGATIVE_ENHANCED)
+			.build();
 
 		Evaluation result = evaluator.evaluate(sample);
 
@@ -136,7 +142,7 @@ class AnswerCorrectnessEvaluatorIntegrationTest
 		// - TP: "Paris is the Capital of France"
 		// - FN: "...of France"
 		//
-        LOG.info("Result: {}", result.getValue());
+		LOG.info("Result: {}", result.getValue());
 		assertEquals(0.66, result.getValue(), 0.1);
 	}
 

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/answerrelevance/llm/AnswerRelevanceLlmEvaluatorIntegrationTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/answerrelevance/llm/AnswerRelevanceLlmEvaluatorIntegrationTest.java
@@ -52,7 +52,7 @@ class AnswerRelevanceLlmEvaluatorIntegrationTest
 		Evaluation result = evaluator.evaluate(sample);
 
 		assertEquals("Answer relevance llm", result.getName());
-		assertEquals(1.0, result.getValue(),0.01, "Expected normalized score = 1.0 for a relevant answer");
+		assertEquals(1.0, result.getValue(), 0.01, "Expected normalized score = 1.0 for a relevant answer");
 	}
 
 	@Tag("integration")
@@ -82,7 +82,7 @@ class AnswerRelevanceLlmEvaluatorIntegrationTest
 		Evaluation result = evaluator.evaluate(sample);
 
 		assertEquals("Answer relevance llm", result.getName());
-		assertEquals(1.0 / 3.0, result.getValue(),0.1, "Expected normalized score 1/3 for a partially relevant answer");
+		assertEquals(1.0 / 3.0, result.getValue(), 0.1, "Expected normalized score 1/3 for a partially relevant answer");
 	}
 
 	@Tag("integration")

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/embedding/ContextRelevanceEmbeddingEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/embedding/ContextRelevanceEmbeddingEvaluatorTest.java
@@ -40,7 +40,7 @@ class ContextRelevanceEmbeddingEvaluatorTest
 	}
 
 	@ParameterizedTest
-	@ValueSource(doubles = {0.95, 0.2, 0.0})
+	@ValueSource(doubles = { 0.95, 0.2, 0.0 })
 	void testEvaluateWithSimilarity(double similarity)
 	{
 		when(mockSimilarityBatchComputer.apply(QUESTION, List.of(CONTEXT))).thenReturn(List.of(similarity));

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluatorIntegrationTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluatorIntegrationTest.java
@@ -49,7 +49,7 @@ class ContextRelevanceLlmEvaluatorIntegrationTest
 		Evaluation result = evaluator.evaluate(sample);
 
 		assertEquals("Context relevance LLM", result.getName());
-		assertEquals(1.0, result.getValue(),0.01,"Expected normalized score 1.0 for highly relevant context");
+		assertEquals(1.0, result.getValue(), 0.01, "Expected normalized score 1.0 for highly relevant context");
 	}
 
 	@Tag("integration")
@@ -64,7 +64,7 @@ class ContextRelevanceLlmEvaluatorIntegrationTest
 		Evaluation result = evaluator.evaluate(sample);
 
 		assertEquals("Context relevance LLM", result.getName());
-		assertEquals(0.0, result.getValue(),0.01,"Expected score 0.0 for irrelevant context");
+		assertEquals(0.0, result.getValue(), 0.01, "Expected score 0.0 for irrelevant context");
 	}
 
 	@Tag("integration")

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluatorTest.java
@@ -1,14 +1,23 @@
 package dev.rage4j.evaluation.contextrelevance.llm;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.rage4j.LoggingTestWatcher;
 import dev.rage4j.evaluation.Evaluation;
+import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,7 +48,7 @@ class ContextRelevanceLlmEvaluatorTest
 	@Test
 	void testEvaluatePerfectScore()
 	{
-		when(mockBot.generateScore(QUESTION, CONTEXT)).thenReturn("3");
+		when(mockBot.generateScore(anyList(), eq(QUESTION), eq(CONTEXT))).thenReturn("3");
 
 		Evaluation result = evaluator.evaluate(sample);
 
@@ -50,7 +59,7 @@ class ContextRelevanceLlmEvaluatorTest
 	@Test
 	void testEvaluateMostlyRelevant()
 	{
-		when(mockBot.generateScore(QUESTION, CONTEXT)).thenReturn("2");
+		when(mockBot.generateScore(anyList(), anyString(), eq(CONTEXT))).thenReturn("2");
 
 		Evaluation result = evaluator.evaluate(sample);
 
@@ -61,7 +70,7 @@ class ContextRelevanceLlmEvaluatorTest
 	@Test
 	void testEvaluatePartiallyRelevant()
 	{
-		when(mockBot.generateScore(QUESTION, IRRELEVANT_CONTEXT)).thenReturn("1");
+		when(mockBot.generateScore(anyList(), anyString(), eq(IRRELEVANT_CONTEXT))).thenReturn("1");
 
 		Sample irrelevantSample = Sample.builder()
 			.withQuestion(QUESTION)
@@ -77,7 +86,7 @@ class ContextRelevanceLlmEvaluatorTest
 	@Test
 	void testEvaluateNoRelevance()
 	{
-		when(mockBot.generateScore(QUESTION, IRRELEVANT_CONTEXT)).thenReturn("0");
+		when(mockBot.generateScore(anyList(), anyString(), anyString())).thenReturn("0");
 
 		Sample irrelevantSample = Sample.builder()
 			.withQuestion(QUESTION)
@@ -102,13 +111,12 @@ class ContextRelevanceLlmEvaluatorTest
 			.withContext(multiChunkContext)
 			.build();
 
-		when(mockBot.generateScore(QUESTION, multiChunkContext)).thenReturn("2");
+		when(mockBot.generateScore(anyList(), anyString(), eq(multiChunkContext))).thenReturn("2");
 
 		Evaluation result = evaluator.evaluate(multiChunkSample);
 
 		assertEquals(2.0 / 3.0, result.getValue(), 0.001);
 		assertEquals("Context relevance LLM", result.getName());
-		verify(mockBot).generateScore(QUESTION, multiChunkContext);
 	}
 
 	@Test
@@ -123,7 +131,7 @@ class ContextRelevanceLlmEvaluatorTest
 
 		assertEquals(0.0, result.getValue(), 0.001);
 		assertEquals("Context relevance LLM", result.getName());
-		verify(mockBot, never()).generateScore(QUESTION, "   ");
+		verify(mockBot, never()).generateScore(anyList(), anyString(), anyString());
 	}
 
 	@Test
@@ -152,5 +160,73 @@ class ContextRelevanceLlmEvaluatorTest
 			IllegalArgumentException.class,
 			() -> evaluator.evaluate(nullQuestionSample));
 		assertEquals("Sample must have a question for Context Relevance LLM evaluation", exception.getMessage());
+	}
+
+	@Test
+	void testEvaluateImagesWithoutVisionThrows()
+	{
+		Sample sampleWithImages = Sample.builder()
+			.withQuestion(QUESTION)
+			.withContext(CONTEXT)
+			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash.png"))
+			.build();
+
+		UnsupportedOperationException exception = assertThrows(
+			UnsupportedOperationException.class,
+			() -> evaluator.evaluate(sampleWithImages));
+		assertTrue(exception.getMessage().contains("Context relevance"));
+		assertTrue(exception.getMessage().contains("vision"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testEvaluateForwardsImagesWhenVisionEnabled()
+	{
+		ContextRelevanceLlmBot visionBot = mock(ContextRelevanceLlmBot.class);
+		ContextRelevanceLlmEvaluator visionEvaluator = new ContextRelevanceLlmEvaluator(visionBot, true);
+
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash-1.png");
+		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/clash-2.jpg");
+		Sample sampleWithImages = Sample.builder()
+			.withQuestion(QUESTION)
+			.withContext(CONTEXT)
+			.withImages(List.of(img1, img2))
+			.build();
+
+		when(visionBot.generateScore(anyList(), anyString(), anyString())).thenReturn("3");
+
+		Evaluation result = visionEvaluator.evaluate(sampleWithImages);
+
+		assertEquals(1.0, result.getValue(), 0.001);
+		ArgumentCaptor<List<ImageContent>> imageCaptor = ArgumentCaptor.forClass(List.class);
+		ArgumentCaptor<String> questionCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> contextCaptor = ArgumentCaptor.forClass(String.class);
+		verify(visionBot).generateScore(imageCaptor.capture(), questionCaptor.capture(), contextCaptor.capture());
+		assertEquals(QUESTION, questionCaptor.getValue());
+		assertEquals(CONTEXT, contextCaptor.getValue());
+		assertEquals(2, imageCaptor.getValue().size());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testEvaluateBlankContextWithImagesScoresAnyway()
+	{
+		ContextRelevanceLlmBot visionBot = mock(ContextRelevanceLlmBot.class);
+		ContextRelevanceLlmEvaluator visionEvaluator = new ContextRelevanceLlmEvaluator(visionBot, true);
+
+		Sample blankCtxWithImages = Sample.builder()
+			.withQuestion(QUESTION)
+			.withContext("   ")
+			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash.png"))
+			.build();
+
+		when(visionBot.generateScore(anyList(), anyString(), anyString())).thenReturn("2");
+
+		Evaluation result = visionEvaluator.evaluate(blankCtxWithImages);
+
+		assertEquals(2.0 / 3.0, result.getValue(), 0.001);
+		ArgumentCaptor<List<ImageContent>> imageCaptor = ArgumentCaptor.forClass(List.class);
+		verify(visionBot).generateScore(imageCaptor.capture(), anyString(), anyString());
+		assertEquals(1, imageCaptor.getValue().size());
 	}
 }

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/contextrelevance/llm/ContextRelevanceLlmEvaluatorTest.java
@@ -168,7 +168,7 @@ class ContextRelevanceLlmEvaluatorTest
 		Sample sampleWithImages = Sample.builder()
 			.withQuestion(QUESTION)
 			.withContext(CONTEXT)
-			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash.png"))
+			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "landmark.png"))
 			.build();
 
 		UnsupportedOperationException exception = assertThrows(
@@ -185,8 +185,8 @@ class ContextRelevanceLlmEvaluatorTest
 		ContextRelevanceLlmBot visionBot = mock(ContextRelevanceLlmBot.class);
 		ContextRelevanceLlmEvaluator visionEvaluator = new ContextRelevanceLlmEvaluator(visionBot, true);
 
-		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash-1.png");
-		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/clash-2.jpg");
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "eiffel-tower.png");
+		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/louvre.jpg");
 		Sample sampleWithImages = Sample.builder()
 			.withQuestion(QUESTION)
 			.withContext(CONTEXT)
@@ -217,7 +217,7 @@ class ContextRelevanceLlmEvaluatorTest
 		Sample blankCtxWithImages = Sample.builder()
 			.withQuestion(QUESTION)
 			.withContext("   ")
-			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash.png"))
+			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "landmark.png"))
 			.build();
 
 		when(visionBot.generateScore(anyList(), anyString(), anyString())).thenReturn("2");

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluatorTest.java
@@ -1,18 +1,27 @@
 package dev.rage4j.evaluation.faithfulness;
 
+import dev.langchain4j.data.message.ImageContent;
 import dev.rage4j.LoggingTestWatcher;
 import dev.rage4j.evaluation.Evaluation;
 import dev.rage4j.evaluation.model.ArrayResponse;
+import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(LoggingTestWatcher.class)
@@ -47,7 +56,7 @@ class FaithfulnessEvaluatorTest
 	void testEvaluateFaithfulness_FullMatch()
 	{
 		when(mockBot.extractClaims(ANSWER)).thenReturn(new ArrayResponse(new String[] { "Paris" }));
-		when(mockBot.canBeInferred(anyString(), eq("Paris"))).thenReturn(true);
+		when(mockBot.canBeInferred(anyList(), eq("Paris"), anyString())).thenReturn(true);
 
 		Evaluation result = evaluator.evaluate(sample);
 
@@ -59,8 +68,8 @@ class FaithfulnessEvaluatorTest
 	void testEvaluateFaithfulness_PartialMatch()
 	{
 		when(mockBot.extractClaims(ANSWER)).thenReturn(new ArrayResponse(new String[] { "Paris", "London" }));
-		when(mockBot.canBeInferred(anyString(), eq("Paris"))).thenReturn(true);
-		when(mockBot.canBeInferred(anyString(), eq("London"))).thenReturn(false);
+		when(mockBot.canBeInferred(anyList(), eq("Paris"), anyString())).thenReturn(true);
+		when(mockBot.canBeInferred(anyList(), eq("London"), anyString())).thenReturn(false);
 
 		Evaluation result = evaluator.evaluate(sample);
 
@@ -72,8 +81,7 @@ class FaithfulnessEvaluatorTest
 	void testEvaluateFaithfulness_NoMatch()
 	{
 		when(mockBot.extractClaims(ANSWER)).thenReturn(new ArrayResponse(new String[] { "London", "Berlin" }));
-		when(mockBot.canBeInferred(anyString(), eq("London"))).thenReturn(false);
-		when(mockBot.canBeInferred(anyString(), eq("Berlin"))).thenReturn(false);
+		when(mockBot.canBeInferred(anyList(), anyString(), anyString())).thenReturn(false);
 
 		Evaluation result = evaluator.evaluate(sample);
 
@@ -118,5 +126,75 @@ class FaithfulnessEvaluatorTest
 
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> evaluator.evaluate(nullAnswerSample));
 		assertEquals("Sample must have an answer for Faithfulness evaluation", exception.getMessage());
+	}
+
+	@Test
+	void testEvaluateFaithfulnessImagesWithoutVisionThrows()
+	{
+		Sample sampleWithImages = Sample.builder()
+			.withQuestion(QUESTION)
+			.withAnswer(ANSWER)
+			.withGroundTruth(GROUND_TRUTH)
+			.withContext(CONTEXT)
+			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash.png"))
+			.build();
+
+		UnsupportedOperationException exception = assertThrows(
+			UnsupportedOperationException.class,
+			() -> evaluator.evaluate(sampleWithImages));
+		assertTrue(exception.getMessage().contains("Faithfulness"));
+		assertTrue(exception.getMessage().contains("vision"));
+		// bot must not be invoked at all when the guard fires
+		verify(mockBot, never()).extractClaims(anyString());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testEvaluateFaithfulnessForwardsImagesWhenVisionEnabled()
+	{
+		FaithfulnessBot visionBot = mock(FaithfulnessBot.class);
+		FaithfulnessEvaluator visionEvaluator = new FaithfulnessEvaluator(visionBot, true);
+
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash-1.png");
+		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/clash-2.jpg");
+		Sample sampleWithImages = Sample.builder()
+			.withQuestion(QUESTION)
+			.withAnswer(ANSWER)
+			.withGroundTruth(GROUND_TRUTH)
+			.withContext(CONTEXT)
+			.withImages(List.of(img1, img2))
+			.build();
+
+		when(visionBot.extractClaims(ANSWER)).thenReturn(new ArrayResponse(new String[] { "Paris" }));
+		when(visionBot.canBeInferred(anyList(), anyString(), anyString())).thenReturn(true);
+
+		Evaluation result = visionEvaluator.evaluate(sampleWithImages);
+
+		assertEquals(EXPECTED_SCORE_FULL_MATCH, result.getValue());
+		ArgumentCaptor<List<ImageContent>> imageCaptor = ArgumentCaptor.forClass(List.class);
+		ArgumentCaptor<String> claimCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> contextCaptor = ArgumentCaptor.forClass(String.class);
+		verify(visionBot).canBeInferred(imageCaptor.capture(), claimCaptor.capture(), contextCaptor.capture());
+		assertEquals("Paris", claimCaptor.getValue());
+		assertEquals(CONTEXT, contextCaptor.getValue());
+		assertEquals(2, imageCaptor.getValue().size());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testEvaluateFaithfulnessVisionEnabledButNoImagesPassesEmptyList()
+	{
+		FaithfulnessBot visionBot = mock(FaithfulnessBot.class);
+		FaithfulnessEvaluator visionEvaluator = new FaithfulnessEvaluator(visionBot, true);
+
+		when(visionBot.extractClaims(ANSWER)).thenReturn(new ArrayResponse(new String[] { "Paris" }));
+		when(visionBot.canBeInferred(anyList(), anyString(), anyString())).thenReturn(true);
+
+		Evaluation result = visionEvaluator.evaluate(sample);
+
+		assertEquals(EXPECTED_SCORE_FULL_MATCH, result.getValue());
+		ArgumentCaptor<List<ImageContent>> imageCaptor = ArgumentCaptor.forClass(List.class);
+		verify(visionBot).canBeInferred(imageCaptor.capture(), anyString(), anyString());
+		assertTrue(imageCaptor.getValue().isEmpty());
 	}
 }

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/faithfulness/FaithfulnessEvaluatorTest.java
@@ -136,7 +136,7 @@ class FaithfulnessEvaluatorTest
 			.withAnswer(ANSWER)
 			.withGroundTruth(GROUND_TRUTH)
 			.withContext(CONTEXT)
-			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash.png"))
+			.withImage(Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "landmark.png"))
 			.build();
 
 		UnsupportedOperationException exception = assertThrows(
@@ -155,8 +155,8 @@ class FaithfulnessEvaluatorTest
 		FaithfulnessBot visionBot = mock(FaithfulnessBot.class);
 		FaithfulnessEvaluator visionEvaluator = new FaithfulnessEvaluator(visionBot, true);
 
-		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "clash-1.png");
-		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/clash-2.jpg");
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "eiffel-tower.png");
+		Rage4jImage img2 = Rage4jImage.fromUrl("https://example.com/louvre.jpg");
 		Sample sampleWithImages = Sample.builder()
 			.withQuestion(QUESTION)
 			.withAnswer(ANSWER)

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/Rage4jImageTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/Rage4jImageTest.java
@@ -25,9 +25,9 @@ class Rage4jImageTest
 	@Test
 	void testFromBytesPopulatesAllFields()
 	{
-		Rage4jImage image = Rage4jImage.fromBytes(TEST_BYTES, "image/png", "clash-1.png");
+		Rage4jImage image = Rage4jImage.fromBytes(TEST_BYTES, "image/png", "eiffel-tower.png");
 
-		assertEquals("clash-1.png", image.getName());
+		assertEquals("eiffel-tower.png", image.getName());
 		assertEquals("image/png", image.getMimeType());
 		assertNull(image.getUrl());
 		assertTrue(image.hasInlineData());
@@ -47,9 +47,9 @@ class Rage4jImageTest
 	@Test
 	void testFromUrlDerivesNameFromLastSegment()
 	{
-		Rage4jImage image = Rage4jImage.fromUrl("https://example.com/path/clash.jpg");
+		Rage4jImage image = Rage4jImage.fromUrl("https://example.com/path/landmark.jpg");
 
-		assertEquals("clash.jpg", image.getName());
+		assertEquals("landmark.jpg", image.getName());
 		assertEquals("image/jpeg", image.getMimeType());
 		assertNotNull(image.getUrl());
 		assertFalse(image.hasInlineData());
@@ -65,12 +65,12 @@ class Rage4jImageTest
 	@Test
 	void testFromPathReadsBytesAndDerivesNameAndMime(@TempDir Path tmp) throws IOException
 	{
-		Path file = tmp.resolve("clash-2.JPEG");
+		Path file = tmp.resolve("notre-dame.JPEG");
 		Files.write(file, TEST_BYTES);
 
 		Rage4jImage image = Rage4jImage.fromPath(file);
 
-		assertEquals("clash-2.JPEG", image.getName());
+		assertEquals("notre-dame.JPEG", image.getName());
 		assertEquals("image/jpeg", image.getMimeType());
 		assertArrayEquals(TEST_BYTES, image.getData());
 	}

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/Rage4jImageTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/Rage4jImageTest.java
@@ -1,0 +1,109 @@
+package dev.rage4j.model;
+
+import dev.langchain4j.data.message.ImageContent;
+import dev.rage4j.LoggingTestWatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(LoggingTestWatcher.class)
+class Rage4jImageTest
+{
+	private static final byte[] TEST_BYTES = new byte[] { 1, 2, 3, 4 };
+
+	@Test
+	void testFromBytesPopulatesAllFields()
+	{
+		Rage4jImage image = Rage4jImage.fromBytes(TEST_BYTES, "image/png", "clash-1.png");
+
+		assertEquals("clash-1.png", image.getName());
+		assertEquals("image/png", image.getMimeType());
+		assertNull(image.getUrl());
+		assertTrue(image.hasInlineData());
+		assertArrayEquals(TEST_BYTES, image.getData());
+	}
+
+	@Test
+	void testFromBytesDefensivelyCopiesData()
+	{
+		byte[] original = new byte[] { 1, 2, 3 };
+		Rage4jImage image = Rage4jImage.fromBytes(original, "image/png", "a.png");
+
+		original[0] = 99;
+		assertEquals(1, image.getData()[0]);
+	}
+
+	@Test
+	void testFromUrlDerivesNameFromLastSegment()
+	{
+		Rage4jImage image = Rage4jImage.fromUrl("https://example.com/path/clash.jpg");
+
+		assertEquals("clash.jpg", image.getName());
+		assertEquals("image/jpeg", image.getMimeType());
+		assertNotNull(image.getUrl());
+		assertFalse(image.hasInlineData());
+	}
+
+	@Test
+	void testFromUrlAllowsExplicitName()
+	{
+		Rage4jImage image = Rage4jImage.fromUrl("https://example.com/x.png", "renamed.png");
+		assertEquals("renamed.png", image.getName());
+	}
+
+	@Test
+	void testFromPathReadsBytesAndDerivesNameAndMime(@TempDir Path tmp) throws IOException
+	{
+		Path file = tmp.resolve("clash-2.JPEG");
+		Files.write(file, TEST_BYTES);
+
+		Rage4jImage image = Rage4jImage.fromPath(file);
+
+		assertEquals("clash-2.JPEG", image.getName());
+		assertEquals("image/jpeg", image.getMimeType());
+		assertArrayEquals(TEST_BYTES, image.getData());
+	}
+
+	@Test
+	void testToImageContentForUrlBacked()
+	{
+		Rage4jImage image = Rage4jImage.fromUrl("https://example.com/x.png");
+		ImageContent content = image.toImageContent();
+
+		assertNotNull(content);
+		assertEquals("https://example.com/x.png", content.image().url().toString());
+	}
+
+	@Test
+	void testToImageContentForBytesBacked()
+	{
+		Rage4jImage image = Rage4jImage.fromBytes(TEST_BYTES, "image/png", "a.png");
+		ImageContent content = image.toImageContent();
+
+		assertNotNull(content);
+		assertEquals("image/png", content.image().mimeType());
+		assertNotNull(content.image().base64Data());
+	}
+
+	@Test
+	void testGuessMimeFallback()
+	{
+		Rage4jImage image = Rage4jImage.fromBytes(TEST_BYTES, "image/png", "no-extension");
+		// caller-supplied mime takes precedence regardless of name
+		assertEquals("image/png", image.getMimeType());
+
+		Rage4jImage byPath = Rage4jImage.fromUrl("https://example.com/file.unknown");
+		assertEquals("application/octet-stream", byPath.getMimeType());
+	}
+}

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/SampleTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/SampleTest.java
@@ -7,8 +7,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(LoggingTestWatcher.class)
 class SampleTest
@@ -110,5 +115,53 @@ class SampleTest
 			.build();
 
 		assertNull(nullContextSample.getContext());
+	}
+
+	@Test
+	void testGetImagesReturnsEmptyListWhenNotSet()
+	{
+		assertTrue(sample.getImages().isEmpty());
+		assertFalse(sample.hasImages());
+	}
+
+	@Test
+	void testWithImageAddsSingleImage()
+	{
+		Rage4jImage image = Rage4jImage.fromBytes(new byte[] { 1, 2, 3 }, "image/png", "clash-1.png");
+		Sample withImage = Sample.builder()
+			.withQuestion(QUESTION)
+			.withContext(CONTEXT)
+			.withAnswer(ANSWER)
+			.withImage(image)
+			.build();
+
+		assertTrue(withImage.hasImages());
+		assertEquals(1, withImage.getImages().size());
+		assertEquals(image, withImage.getImages().get(0));
+	}
+
+	@Test
+	void testWithImagesReplacesList()
+	{
+		Rage4jImage img1 = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "a.png");
+		Rage4jImage img2 = Rage4jImage.fromBytes(new byte[] { 2 }, "image/png", "b.png");
+		Sample withImages = Sample.builder()
+			.withQuestion(QUESTION)
+			.withImages(List.of(img1, img2))
+			.build();
+
+		assertEquals(2, withImages.getImages().size());
+	}
+
+	@Test
+	void testGetImagesIsUnmodifiable()
+	{
+		Rage4jImage image = Rage4jImage.fromBytes(new byte[] { 1 }, "image/png", "a.png");
+		Sample withImage = Sample.builder()
+			.withQuestion(QUESTION)
+			.withImage(image)
+			.build();
+
+		assertThrows(UnsupportedOperationException.class, () -> withImage.getImages().add(image));
 	}
 }

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/SampleTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/SampleTest.java
@@ -127,7 +127,7 @@ class SampleTest
 	@Test
 	void testWithImageAddsSingleImage()
 	{
-		Rage4jImage image = Rage4jImage.fromBytes(new byte[] { 1, 2, 3 }, "image/png", "clash-1.png");
+		Rage4jImage image = Rage4jImage.fromBytes(new byte[] { 1, 2, 3 }, "image/png", "eiffel-tower.png");
 		Sample withImage = Sample.builder()
 			.withQuestion(QUESTION)
 			.withContext(CONTEXT)

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/util/ContextChunkerTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/util/ContextChunkerTest.java
@@ -106,4 +106,3 @@ class ContextChunkerTest
 		assertEquals(chunks.get(0).substring(850), chunks.get(1).substring(0, 150));
 	}
 }
-

--- a/docusaurus/docs/rage4j-assert/examples.md
+++ b/docusaurus/docs/rage4j-assert/examples.md
@@ -106,6 +106,32 @@ rageAssert.given()
 This example uses the [`assertRougeScore`](/docs/rage4j-core/metrics/rouge_score) feature, with the **ROUGE_L_SUM**
 metric. This example makes sure that the LCS across multiple sentences yields a precision of 0.9.
 
+### Example: Testing Faithfulness with images
+
+When the system under test consumed images alongside the textual context,
+attach them via `.image(...)` (or `.images(List)`). The configured
+`ChatModel` must be vision-capable &mdash; calling `.image(...)` is treated as
+an implicit opt-in and the underlying `FaithfulnessEvaluator` is built with
+vision support enabled. See [Image support](/docs/rage4j-core/image_support)
+for the full reference.
+
+``` java
+import dev.rage4j.model.Rage4jImage;
+import java.nio.file.Path;
+
+RageAssert rageAssert = new OpenAiLLMBuilder().fromApiKey(key); // model must support vision
+rageAssert.given()
+    .question("What landmarks are mentioned in the document?")
+    .context("Paris is the capital of France and home to many landmarks.")
+    .image(Rage4jImage.fromPath(Path.of("eiffel-tower.jpg")))
+    .image(Rage4jImage.fromPath(Path.of("louvre.png")))
+    .groundTruth(GROUND_TRUTH)
+    .when()
+    .answer(model::generate)
+    .then()
+    .assertFaithfulness(0.7);
+```
+
 ### Example: Concatenation of multiple assertions
 
 ``` java

--- a/docusaurus/docs/rage4j-core/core_concepts.md
+++ b/docusaurus/docs/rage4j-core/core_concepts.md
@@ -22,6 +22,18 @@ A Sample typically consists of:
 - An **answer**: the model-generated response.
 - A **ground truth**: the expected or correct answer.
 - A **context** (optional): additional information related to the question.
+- **Images** (optional): part of the context, forwarded to vision-capable
+  evaluators. See [Image support](image_support) for details.
+
+```java
+Sample sampleWithImages = Sample.builder()
+    .withQuestion("What landmarks are mentioned in the document?")
+    .withContext("Paris is the capital of France and home to many landmarks.")
+    .withImage(Rage4jImage.fromPath(Path.of("eiffel-tower.jpg")))
+    .withImage(Rage4jImage.fromPath(Path.of("louvre.png")))
+    .withAnswer(answer)
+    .build();
+```
 
 ---
 

--- a/docusaurus/docs/rage4j-core/image_support.md
+++ b/docusaurus/docs/rage4j-core/image_support.md
@@ -1,0 +1,127 @@
+---
+title: Image support
+sidebar_position: 3
+---
+
+# Image support
+
+RAGE4j evaluators can pass images to the judging LLM alongside the textual
+context. This is intended for RAG systems where the answer was produced from a
+mix of text and images (e.g. diagrams, charts, screenshots, photographs) and
+the evaluator needs to "see" the same images to make a fair judgment.
+
+## When to use
+
+Images are part of the **context** &mdash; what the system under test had to work
+with &mdash; not part of the question. Today they are forwarded by:
+
+- `FaithfulnessEvaluator` &ndash; checks each answer claim against text context
+  **plus** images.
+- `ContextRelevanceLlmEvaluator` &ndash; scores how relevant the combined
+  text-and-image context is to the question.
+
+Other evaluators (`AnswerCorrectness`, `AnswerRelevance`, `BLEU`, `ROUGE`,
+`SemanticSimilarity`) deliberately ignore images. Their metrics are either
+purely textual (correctness vs. ground truth) or numeric (n-gram / embedding
+based) and would not benefit from a visual signal.
+
+## Attaching images to a Sample
+
+`Rage4jImage` exposes three factory methods. The image name is required for
+persistence and is auto-derived where possible.
+
+```java
+import dev.rage4j.model.Rage4jImage;
+import java.nio.file.Path;
+
+Rage4jImage fromFile  = Rage4jImage.fromPath(Path.of("eiffel-tower.jpg"));
+Rage4jImage fromUrl   = Rage4jImage.fromUrl("https://example.com/paris-map.png");
+Rage4jImage fromBytes = Rage4jImage.fromBytes(bytes, "image/png", "louvre.png");
+
+Sample sample = Sample.builder()
+    .withQuestion("What landmarks are mentioned in the document?")
+    .withContext("Paris is the capital of France and home to many landmarks.")
+    .withImages(List.of(fromFile, fromUrl, fromBytes))
+    .withAnswer(answer)
+    .build();
+```
+
+`fromPath` reads the file eagerly and derives the MIME type from the extension
+(`.png`, `.jpg/.jpeg`, `.gif`, `.webp`, `.bmp`).
+
+## Vision-capable models
+
+The judging `ChatModel` must support multimodal input (e.g. `gpt-4o`,
+`gpt-4o-mini`). LangChain4j 1.x does not expose a vision capability flag on
+`ChatModel`, so the evaluator cannot detect this automatically. You opt in
+explicitly:
+
+```java
+ChatModel visionModel = OpenAiChatModel.builder()
+    .apiKey(apiKey)
+    .modelName("gpt-4o-mini")
+    .build();
+
+FaithfulnessEvaluator evaluator = new FaithfulnessEvaluator(visionModel, true);
+ContextRelevanceLlmEvaluator ctx = new ContextRelevanceLlmEvaluator(visionModel, true);
+```
+
+If a sample contains images but the evaluator was constructed **without** the
+vision flag, an `UnsupportedOperationException` is thrown before any LLM call:
+
+```text
+Faithfulness evaluator received a Sample with 3 image(s) but was not
+configured for vision. Pass a vision-capable ChatModel (e.g. gpt-4o)
+and use the constructor variant that takes supportsVision=true.
+```
+
+The text-only constructors (`new FaithfulnessEvaluator(model)`) keep their
+original behaviour and are still the right choice for samples without images.
+
+## End-to-end example
+
+```java
+ChatModel visionModel = OpenAiChatModel.builder()
+    .apiKey(apiKey)
+    .modelName("gpt-4o-mini")
+    .build();
+
+Sample sample = Sample.builder()
+    .withQuestion("What landmarks are mentioned in the document?")
+    .withContext("Paris is the capital of France and home to many landmarks.")
+    .withImages(List.of(
+        Rage4jImage.fromPath(Path.of("eiffel-tower.jpg")),
+        Rage4jImage.fromPath(Path.of("louvre.png")),
+        Rage4jImage.fromPath(Path.of("notre-dame.jpg"))))
+    .withAnswer(answer)
+    .withGroundTruth("Eiffel Tower, Louvre, and Notre-Dame are among the famous landmarks of Paris.")
+    .build();
+
+FaithfulnessEvaluator faithfulness =
+    new FaithfulnessEvaluator(visionModel, true);
+ContextRelevanceLlmEvaluator relevance =
+    new ContextRelevanceLlmEvaluator(visionModel, true);
+
+Evaluation faithfulnessScore = faithfulness.evaluate(sample);
+Evaluation contextScore      = relevance.evaluate(sample);
+```
+
+## Persistence
+
+When samples are written through the persist module, only image **names** are
+stored &ndash; the bytes never reach the JSONL file:
+
+```json
+{
+  "sample": {
+    "question": "What landmarks are mentioned in the document?",
+    "context": "Paris is the capital of France and home to many landmarks.",
+    "images": ["eiffel-tower.jpg", "louvre.png", "notre-dame.jpg"]
+  },
+  "metrics": { "Faithfulness": 0.83, "Context relevance LLM": 1.0 }
+}
+```
+
+If you need to re-run evaluations from a stored record, keep the original
+images on disk and re-attach them via `Rage4jImage.fromPath(...)` using the
+name as a lookup key.

--- a/docusaurus/docs/rage4j-core/metrics/faithfulness.md
+++ b/docusaurus/docs/rage4j-core/metrics/faithfulness.md
@@ -29,3 +29,16 @@ FaithfulnessEvaluator evaluator = new FaithfulnessEvaluator(chatModel);
 Evaluation result = evaluator.evaluate(sample);
 double faithfulnessScore = result.getValue();
 ```
+
+## With images in the context
+
+If the sample carries images (`sample.hasImages() == true`), construct the
+evaluator with a vision-capable `ChatModel` and the explicit
+`supportsVision=true` flag. The bot then receives both text context and
+images when checking each claim. See [Image support](../image_support) for
+details.
+
+```java
+FaithfulnessEvaluator visionEvaluator =
+    new FaithfulnessEvaluator(gpt4oModel, /*supportsVision=*/ true);
+```


### PR DESCRIPTION
## Image input support for Sample-based evaluation                                                                                                                                                                                                
                                                                                                                                                                                                                                                    
  Adds optional images to `Sample`, forwarded to vision-capable judging LLMs.                                                                                                                                                                                                                                                                                                                                                                      
                  
  ### Changes                                                                                                                                                                                                                                       
  - New `Rage4jImage` type (`fromPath` / `fromBytes` / `fromUrl`) and
    `Sample.builder().withImage(...) / .withImages(...)`.                                                                                                                                                                                           
  - `FaithfulnessEvaluator` and `ContextRelevanceLlmEvaluator` forward images
    when constructed with `supportsVision=true`. `VisionModelGuard` fails fast                                                                                                                                                                      
    if images are present but vision is not enabled.                                                                                                                                                                                                                                                                                                                                             
  - JSONL persistence stores image **names** only                                                                                                                                                                           
  - Upgrades `langchain4j` 1.0.1 → 1.7.1.                                                                                                                                                                                                           

New docs page `docs/rage4j-core/image_support.md` plus examples updated.                                                                                                                                                               
