### PR TITLE
Feature/junit html report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Rage4J is a RAG (Retrieval-Augmented Generation) Evaluation library for Java. It provides tools to evaluate and measure the quality of language model outputs using various metrics like correctness, relevance, faithfulness, and semantic similarity.
+
+## Build Commands
+
+```bash
+# Build the entire project (from root)
+./mvnw clean install
+
+# Run unit tests only (excludes integration tests by default)
+./mvnw test
+
+# Run integration tests (requires OPEN_AI_KEY environment variable)
+./mvnw test -DincludedGroups=integration -DexcludedGroups=
+
+# Run a single test class
+./mvnw test -pl dev.rage4j.rage4j -Dtest=FaithfulnessEvaluatorTest
+
+# Run a single test method
+./mvnw test -pl dev.rage4j.rage4j -Dtest=FaithfulnessEvaluatorTest#testMethodName
+
+# Format code
+./mvnw formatter:format
+
+# Validate formatting
+./mvnw formatter:validate
+
+# Enable detailed metric logs during tests
+./mvnw test -Dshow.metric.logs=true
+```
+
+## Project Structure
+
+Multi-module Maven project with parent POM `rage4j-reactor`:
+
+- **dev.rage4j.rage4j** - Core evaluation library with evaluators and model classes
+- **dev.rage4j.rage4j-assert** - Fluent assertion library for RAG evaluation in tests
+- **dev.rage4j.rage4j-persist** - Persistence module for saving evaluation results (JSONL format)
+- **dev.rage4j.rage4j-persist-junit5** - JUnit 5 extension for automatic persistence lifecycle
+
+## Architecture
+
+### Core Module (rage4j)
+
+- `Sample` - Input data model with question, answer, groundTruth, and context fields (builder pattern)
+- `Evaluator` interface - Contract for all evaluators: `Evaluation evaluate(Sample sample)`
+- `Evaluation` - Result with metric name and score value
+- `EvaluationAggregator` - Runs multiple evaluators and returns `EvaluationAggregation`
+
+**Available Evaluators:**
+- `AnswerCorrectnessEvaluator` - Correctness vs ground truth
+- `AnswerRelevanceEvaluator` - Answer relevance to question
+- `FaithfulnessEvaluator` - Claims inferable from context
+- `AnswerSemanticSimilarityEvaluator` - Embedding-based similarity
+- `BleuScoreEvaluator` - BLEU score calculation
+- `RougeScoreEvaluator` - ROUGE score calculation
+
+### Assert Module (rage4j-assert)
+
+Fluent API: `rageAssert.given().question().groundTruth().when().answer().then().assertFaithfulness(0.7)`
+
+- `RageAssert` - Entry point created via `OpenAiLLMBuilder`
+- `AssertionObserver` - Interface for evaluation callbacks (used by persist module)
+
+### Persist Module (rage4j-persist)
+
+- `EvaluationStore` interface with `JsonLinesStore` implementation
+- `PersistingObserver` - Connects rage4j-assert to persistence
+- `Rage4jPersist` - Static API for global store configuration
+
+### JUnit 5 Extension (rage4j-persist-junit5)
+
+- `@Rage4jPersistConfig(file = "path")` - Annotation for test classes
+- `Rage4jPersistExtension` - Manages store lifecycle and injects `EvaluationStore`
+
+## Key Dependencies
+
+- LangChain4j (v1.0.1) - LLM integration (provided scope)
+- JUnit Jupiter 5 - Testing framework
+- Java 21 required
+
+## Code Style
+
+Uses Eclipse-style formatter configured in `formatter/java.xml`. Opening braces on new lines. Run `./mvnw formatter:format` before committing.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ class AiEvaluationTest
 
 Archive `**/target/rage4j-report.html` in Jenkins, or publish it with the HTML Publisher plugin.
 
+<details>
+<summary>Generated HTML example</summary>
+
+```html
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Rage4j evaluation report</title><style>body{font-family:system-ui,sans-serif;max-width:1200px;margin:2rem auto;padding:0 1rem;color:#172033}table{border-collapse:collapse;width:100%;margin:1rem 0}th,td{border:1px solid #d7dce5;padding:.65rem;text-align:left;vertical-align:top}th{background:#f3f5f8}details{max-width:36rem;white-space:pre-wrap}summary{cursor:pointer} .score{font-variant-numeric:tabular-nums}</style></head><body><h1>Rage4j evaluation report</h1><p>Generated 2026-07-16T11:48:38.317199+02:00 · 1 evaluation(s)</p><table><thead><tr><th>#</th><th>Question</th><th>Metrics</th><th>Answer</th></tr></thead><tbody><tr><td>1</td><td>What is the capital of France?</td><td><ul><li><strong>AnswerCorrectness</strong>: <span class="score">1.000</span></li><li><strong>Faithfulness</strong>: <span class="score">1.000</span></li></ul></td><td>Paris is the capital of France.</td></tr></tbody></table></body></html>
+```
+
+</details>
+
 ## Documentation
 Visit our documentation on Github Pages: <a href="https://explore-de.github.io/rage4j/" target="_blank">Visit Docs</a>
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Rage4J provides tools to evaluate and measure the quality of language model outp
 **Modules:**
 - **rage4j** - Core evaluation library with evaluators and model classes
 - **rage4j-assert** - Fluent assertion library for RAG evaluation in tests
-- **rage4j-persist** - Persistence module for saving evaluation results (JSONL format)
-- **rage4j-persist-junit5** - JUnit 5 extension for automatic persistence lifecycle
+- **rage4j-persist** - Persistence module for saving evaluation results (JSONL and HTML reports)
+- **rage4j-persist-junit5** - JUnit 5 extension for evaluation persistence and HTML artifacts
 
 ## Installation
 
@@ -48,6 +48,17 @@ For persistence of evaluations:
 <dependency>
     <groupId>dev.rage4j</groupId>
     <artifactId>rage4j-persist</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
+    <scope>test</scope>
+</dependency>
+```
+
+For JUnit 5 persistence and HTML reports:
+
+```xml
+<dependency>
+    <groupId>dev.rage4j</groupId>
+    <artifactId>rage4j-persist-junit5</artifactId>
     <version>2.0.1-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
@@ -85,6 +96,39 @@ rageAssert.given()
     .then()
     .assertAnswerCorrectness(0.8);
 ```
+
+### HTML evaluation report for Jenkins
+
+Annotate an AI integration-test class with `@Rage4jHtmlReport`. Rage4j injects an `EvaluationStore` and writes a self-contained HTML artifact after the class completes.
+
+```java
+import org.junit.jupiter.api.Test;
+
+import dev.rage4j.persist.EvaluationStore;
+import dev.rage4j.persist.junit5.Rage4jHtmlReport;
+
+@Rage4jHtmlReport(file = "target/rage4j-report.html")
+class AiEvaluationTest
+{
+    @Test
+    void evaluatesAnswer(EvaluationStore store)
+    {
+        EvaluationAggregation result = rageAssert.given()
+            .question("What is the capital of France?")
+            .groundTruth("Paris")
+            .context("Paris is the capital of France.")
+            .when()
+            .answer("Paris")
+            .then()
+            .assertFaithfulness(0.7)
+            .getEvaluationAggregation();
+
+        store.store(result);
+    }
+}
+```
+
+Archive `**/target/rage4j-report.html` in Jenkins, or publish it with the HTML Publisher plugin.
 
 ## Documentation
 Visit our documentation on Github Pages: <a href="https://explore-de.github.io/rage4j/" target="_blank">Visit Docs</a>

--- a/dev.rage4j.rage4j-persist-junit5/README.md
+++ b/dev.rage4j.rage4j-persist-junit5/README.md
@@ -21,6 +21,26 @@ Add this dependency to your `pom.xml`:
 
 ## Usage
 
+### HTML report for Jenkins
+
+Use `@Rage4jHtmlReport` to inject an `EvaluationStore` that produces one self-contained HTML file when the test class finishes. The file is ready to archive as a Jenkins artifact.
+
+```java
+import dev.rage4j.persist.EvaluationStore;
+import dev.rage4j.persist.junit5.Rage4jHtmlReport;
+
+@Rage4jHtmlReport(file = "target/rage4j-report.html")
+class AiEvaluationTest {
+    @Test
+    void evaluatesAnswer(EvaluationStore store) {
+        // evaluate the sample, then persist the resulting aggregation
+        store.store(aggregation);
+    }
+}
+```
+
+Archive `**/target/rage4j-report.html` in Jenkins (or publish it with the HTML Publisher plugin). Existing `@Rage4jPersistConfig` JSONL output remains unchanged.
+
 ### Basic Usage
 
 Annotate your test class with `@Rage4jPersistConfig`:

--- a/dev.rage4j.rage4j-persist-junit5/README.md
+++ b/dev.rage4j.rage4j-persist-junit5/README.md
@@ -23,7 +23,7 @@ Add this dependency to your `pom.xml`:
 
 ### HTML report for Jenkins
 
-Use `@Rage4jHtmlReport` to inject an `EvaluationStore` that produces one self-contained HTML file when the test class finishes. The file is ready to archive as a Jenkins artifact.
+Use `@Rage4jHtmlReport` to inject an `EvaluationStore` that produces one self-contained HTML file when the test class finishes. By default the report filename includes the fully qualified test class name, so reports from different test classes do not overwrite each other. The file is ready to archive as a Jenkins artifact.
 
 ```java
 import dev.rage4j.persist.EvaluationStore;
@@ -39,7 +39,7 @@ class AiEvaluationTest {
 }
 ```
 
-Archive `**/target/rage4j-report.html` in Jenkins (or publish it with the HTML Publisher plugin). Existing `@Rage4jPersistConfig` JSONL output remains unchanged.
+Archive `**/target/rage4j-report-*.html` in Jenkins (or publish it with the HTML Publisher plugin). Existing `@Rage4jPersistConfig` JSONL output remains unchanged.
 
 ### Basic Usage
 

--- a/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jHtmlReport.java
+++ b/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jHtmlReport.java
@@ -1,0 +1,31 @@
+package dev.rage4j.persist.junit5;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Generates a self-contained HTML report from the {@code EvaluationStore}
+ * injected into the annotated test class.
+ *
+ * <p>Archive the configured file as a Jenkins HTML artifact after the test run.</p>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ExtendWith(Rage4jPersistExtension.class)
+public @interface Rage4jHtmlReport
+{
+	/**
+	 * The generated HTML report. Defaults to a conventional Maven target path.
+	 *
+	 * @return the report file path
+	 */
+	String file() default "target/rage4j-report.html";
+}

--- a/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jHtmlReport.java
+++ b/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jHtmlReport.java
@@ -23,9 +23,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface Rage4jHtmlReport
 {
 	/**
-	 * The generated HTML report. Defaults to a conventional Maven target path.
+	 * The generated HTML report. The {@code {class}} placeholder is replaced with
+	 * the fully qualified test class name, which keeps reports from separate test
+	 * classes from overwriting each other.
 	 *
 	 * @return the report file path
 	 */
-	String file() default "target/rage4j-report.html";
+	String file() default "target/rage4j-report-{class}.html";
 }

--- a/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jPersistExtension.java
+++ b/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jPersistExtension.java
@@ -103,9 +103,15 @@ public class Rage4jPersistExtension implements BeforeAllCallback, AfterAllCallba
 		Rage4jHtmlReport htmlReport = findHtmlReport(testClass);
 		if (htmlReport != null)
 		{
-			return new HtmlReportStore(Path.of(htmlReport.file()));
+			return new HtmlReportStore(Path.of(reportPath(htmlReport.file(), testClass)));
 		}
 		return createStore(findConfigOnClass(testClass));
+	}
+
+	static String reportPath(String template, Class<?> testClass)
+	{
+		String className = testClass == null ? "unknown" : testClass.getName();
+		return template.replace("{class}", className);
 	}
 
 	private Rage4jHtmlReport findHtmlReport(Class<?> testClass)

--- a/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jPersistExtension.java
+++ b/dev.rage4j.rage4j-persist-junit5/src/main/java/dev/rage4j/persist/junit5/Rage4jPersistExtension.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 import dev.rage4j.persist.EvaluationStore;
+import dev.rage4j.persist.store.HtmlReportStore;
 
 /**
  * JUnit 5 extension that manages {@link EvaluationStore} lifecycle for test
@@ -48,8 +49,7 @@ public class Rage4jPersistExtension implements BeforeAllCallback, AfterAllCallba
 	@Override
 	public void beforeAll(ExtensionContext context) throws Exception
 	{
-		Rage4jPersistConfig config = findConfig(context);
-		EvaluationStore store = createStore(config);
+		EvaluationStore store = createStore(context);
 
 		ExtensionContext.Store extensionStore = context.getStore(NAMESPACE);
 		extensionStore.put(STORE_KEY, new CloseableStoreWrapper(store));
@@ -97,13 +97,33 @@ public class Rage4jPersistExtension implements BeforeAllCallback, AfterAllCallba
 		return context.getStore(NAMESPACE);
 	}
 
-	private Rage4jPersistConfig findConfig(ExtensionContext context)
+	private EvaluationStore createStore(ExtensionContext context)
 	{
-		return context.getTestClass().map(this::findConfigOnClass).orElseGet(this::defaultConfig);
+		Class<?> testClass = context.getTestClass().orElse(null);
+		Rage4jHtmlReport htmlReport = findHtmlReport(testClass);
+		if (htmlReport != null)
+		{
+			return new HtmlReportStore(Path.of(htmlReport.file()));
+		}
+		return createStore(findConfigOnClass(testClass));
+	}
+
+	private Rage4jHtmlReport findHtmlReport(Class<?> testClass)
+	{
+		if (testClass == null || testClass == Object.class)
+		{
+			return null;
+		}
+		Rage4jHtmlReport report = testClass.getAnnotation(Rage4jHtmlReport.class);
+		return report != null ? report : findHtmlReport(testClass.getSuperclass());
 	}
 
 	private Rage4jPersistConfig findConfigOnClass(Class<?> testClass)
 	{
+		if (testClass == null)
+		{
+			return defaultConfig();
+		}
 		Rage4jPersistConfig config = testClass.getAnnotation(Rage4jPersistConfig.class);
 		if (config != null)
 		{

--- a/dev.rage4j.rage4j-persist-junit5/src/test/java/dev/rage4j/persist/junit5/Rage4jPersistExtensionTest.java
+++ b/dev.rage4j.rage4j-persist-junit5/src/test/java/dev/rage4j/persist/junit5/Rage4jPersistExtensionTest.java
@@ -72,7 +72,14 @@ class Rage4jPersistExtensionTest
 		{
 		}
 
-		assertEquals("target/rage4j-report.html", HtmlReportConfig.class.getAnnotation(Rage4jHtmlReport.class).file());
+		assertEquals("target/rage4j-report-{class}.html", HtmlReportConfig.class.getAnnotation(Rage4jHtmlReport.class).file());
+	}
+
+	@Test
+	void htmlReportPathIncludesTestClassName()
+	{
+		assertEquals("target/rage4j-report-dev.rage4j.persist.junit5.Rage4jPersistExtensionTest.html",
+			Rage4jPersistExtension.reportPath("target/rage4j-report-{class}.html", Rage4jPersistExtensionTest.class));
 	}
 
 	@Test

--- a/dev.rage4j.rage4j-persist-junit5/src/test/java/dev/rage4j/persist/junit5/Rage4jPersistExtensionTest.java
+++ b/dev.rage4j.rage4j-persist-junit5/src/test/java/dev/rage4j/persist/junit5/Rage4jPersistExtensionTest.java
@@ -65,6 +65,17 @@ class Rage4jPersistExtensionTest
 	}
 
 	@Test
+	void htmlReportAnnotationHasDefaultFile()
+	{
+		@Rage4jHtmlReport
+		class HtmlReportConfig
+		{
+		}
+
+		assertEquals("target/rage4j-report.html", HtmlReportConfig.class.getAnnotation(Rage4jHtmlReport.class).file());
+	}
+
+	@Test
 	void jsonLinesStoreWorks() throws IOException
 	{
 		Path jsonlFile = tempDir.resolve("test.jsonl");

--- a/dev.rage4j.rage4j-persist/src/main/java/dev/rage4j/persist/store/HtmlReportStore.java
+++ b/dev.rage4j.rage4j-persist/src/main/java/dev/rage4j/persist/store/HtmlReportStore.java
@@ -112,14 +112,14 @@ public class HtmlReportStore implements EvaluationStore
 
 	private void appendDetail(StringBuilder report, String value)
 	{
-		String escaped = escape(value);
-		if (escaped.length() > 160)
+		if (value.length() > 160)
 		{
-			report.append("<details><summary>").append(escaped, 0, 160).append("…</summary>").append(escaped).append("</details>");
+			String preview = value.substring(0, 160);
+			report.append("<details><summary>").append(escape(preview)).append("…</summary>").append(escape(value)).append("</details>");
 		}
 		else
 		{
-			report.append(escaped);
+			report.append(escape(value));
 		}
 	}
 

--- a/dev.rage4j.rage4j-persist/src/main/java/dev/rage4j/persist/store/HtmlReportStore.java
+++ b/dev.rage4j.rage4j-persist/src/main/java/dev/rage4j/persist/store/HtmlReportStore.java
@@ -1,0 +1,154 @@
+package dev.rage4j.persist.store;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import dev.rage4j.model.EvaluationAggregation;
+import dev.rage4j.persist.EvaluationStore;
+
+/**
+ * An {@link EvaluationStore} that writes a self-contained HTML evaluation
+ * report. The generated file has no external dependencies, so it can be
+ * archived and opened directly from a Jenkins build.
+ */
+public class HtmlReportStore implements EvaluationStore
+{
+	private final Path file;
+	private final List<EvaluationAggregation> aggregations = new ArrayList<>();
+	private boolean closed;
+
+	public HtmlReportStore(Path file)
+	{
+		this.file = file;
+		ensureParentDirectoryExists();
+	}
+
+	@Override
+	public void store(EvaluationAggregation aggregation)
+	{
+		checkNotClosed();
+		aggregations.add(aggregation);
+	}
+
+	@Override
+	public void flush()
+	{
+		checkNotClosed();
+		try
+		{
+			Files.writeString(file, createReport());
+		}
+		catch (IOException e)
+		{
+			throw new UncheckedIOException("Failed to write HTML evaluation report", e);
+		}
+	}
+
+	@Override
+	public void close()
+	{
+		if (!closed)
+		{
+			flush();
+			closed = true;
+		}
+	}
+
+	private String createReport()
+	{
+		StringBuilder report = new StringBuilder("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
+		report.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
+		report.append("<title>Rage4j evaluation report</title><style>");
+		report.append("body{font-family:system-ui,sans-serif;max-width:1200px;margin:2rem auto;padding:0 1rem;color:#172033}");
+		report.append("table{border-collapse:collapse;width:100%;margin:1rem 0}th,td{border:1px solid #d7dce5;padding:.65rem;text-align:left;vertical-align:top}");
+		report.append("th{background:#f3f5f8}details{max-width:36rem;white-space:pre-wrap}summary{cursor:pointer} .score{font-variant-numeric:tabular-nums}");
+		report.append("</style></head><body><h1>Rage4j evaluation report</h1><p>Generated ");
+		report.append(escape(OffsetDateTime.now().toString())).append(" · ").append(aggregations.size()).append(" evaluation(s)</p>");
+
+		if (aggregations.isEmpty())
+		{
+			report.append("<p>No evaluation results were stored.</p>");
+		}
+		else
+		{
+			report.append("<table><thead><tr><th>#</th><th>Question</th><th>Metrics</th><th>Answer</th></tr></thead><tbody>");
+			for (int index = 0; index < aggregations.size(); index++)
+			{
+				EvaluationAggregation aggregation = aggregations.get(index);
+				Map<String, Object> sample = aggregation.sampleMap();
+				report.append("<tr><td>").append(index + 1).append("</td><td>");
+				appendDetail(report, String.valueOf(sample.getOrDefault("question", "—")));
+				report.append("</td><td>");
+				appendMetrics(report, aggregation.getMetrics());
+				report.append("</td><td>");
+				appendDetail(report, String.valueOf(sample.getOrDefault("answer", "—")));
+				report.append("</td></tr>");
+			}
+			report.append("</tbody></table>");
+		}
+		return report.append("</body></html>").toString();
+	}
+
+	private void appendMetrics(StringBuilder report, Map<String, Double> metrics)
+	{
+		if (metrics.isEmpty())
+		{
+			report.append("—");
+			return;
+		}
+		report.append("<ul>");
+		metrics.entrySet().stream().sorted(Map.Entry.comparingByKey(Comparator.naturalOrder())).forEach(entry -> report.append("<li><strong>")
+			.append(escape(entry.getKey())).append("</strong>: <span class=\"score\">").append(String.format("%.3f", entry.getValue()))
+			.append("</span></li>"));
+		report.append("</ul>");
+	}
+
+	private void appendDetail(StringBuilder report, String value)
+	{
+		String escaped = escape(value);
+		if (escaped.length() > 160)
+		{
+			report.append("<details><summary>").append(escaped, 0, 160).append("…</summary>").append(escaped).append("</details>");
+		}
+		else
+		{
+			report.append(escaped);
+		}
+	}
+
+	private String escape(String value)
+	{
+		return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;");
+	}
+
+	private void ensureParentDirectoryExists()
+	{
+		Path parent = file.getParent();
+		try
+		{
+			if (parent != null)
+			{
+				Files.createDirectories(parent);
+			}
+		}
+		catch (IOException e)
+		{
+			throw new UncheckedIOException("Failed to create directory: " + parent, e);
+		}
+	}
+
+	private void checkNotClosed()
+	{
+		if (closed)
+		{
+			throw new IllegalStateException("Store is closed");
+		}
+	}
+}

--- a/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/HtmlReportStoreTest.java
+++ b/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/HtmlReportStoreTest.java
@@ -1,0 +1,38 @@
+package dev.rage4j.persist.store;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.rage4j.model.EvaluationAggregation;
+import dev.rage4j.model.Sample;
+
+class HtmlReportStoreTest
+{
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void writesSelfContainedHtmlReport() throws IOException
+	{
+		Path report = tempDir.resolve("rage4j-report.html");
+		HtmlReportStore store = new HtmlReportStore(report);
+		EvaluationAggregation aggregation = new EvaluationAggregation(Sample.builder().withQuestion("Is <AI> useful?").withAnswer("Yes & safely").build());
+		aggregation.put("Faithfulness", 0.875);
+
+		store.store(aggregation);
+		store.close();
+
+		String content = Files.readString(report);
+		assertTrue(content.contains("Rage4j evaluation report"));
+		assertTrue(content.contains("Is &lt;AI&gt; useful?"));
+		assertTrue(content.contains("Yes &amp; safely"));
+		assertTrue(content.contains("Faithfulness"));
+		assertTrue(content.contains("0.875"));
+	}
+}

--- a/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/HtmlReportStoreTest.java
+++ b/dev.rage4j.rage4j-persist/src/test/java/dev/rage4j/persist/store/HtmlReportStoreTest.java
@@ -35,4 +35,18 @@ class HtmlReportStoreTest
 		assertTrue(content.contains("Faithfulness"));
 		assertTrue(content.contains("0.875"));
 	}
+
+	@Test
+	void preservesEscapedCharactersInLongPreview() throws IOException
+	{
+		Path report = tempDir.resolve("long-report.html");
+		String question = "x".repeat(158) + " & <AI>";
+		HtmlReportStore store = new HtmlReportStore(report);
+		store.store(new EvaluationAggregation(Sample.builder().withQuestion(question).withAnswer("answer").build()));
+		store.close();
+
+		String content = Files.readString(report);
+		assertTrue(content.contains("x".repeat(158) + " &amp;…"));
+		assertTrue(content.contains(question.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")));
+	}
 }


### PR DESCRIPTION
Adds self-contained HTML evaluation reports for JUnit 5 test runs.

- Introduces `@Rage4jHtmlReport` for injecting an `EvaluationStore` that produces a Jenkins-friendly HTML artifact.
- Adds `HtmlReportStore`, which renders evaluation questions, answers, and metric scores into a standalone report.
- Uses class-specific default report filenames to prevent reports from separate test classes overwriting each other.
- Escapes report content safely and preserves escaped text in truncated previews.
- Documents Jenkins archiving usage and adds regression coverage.

## Validation

- `mvn -B test -pl dev.rage4j.rage4j-persist,dev.rage4j.rage4j-persist-junit5 -am`