### PR TITLE
✨ Tool Call Accuracy: assert which tools an AI service invoked

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ RAG Evaluation library for Java.
 
 ## Overview
 
-Rage4J provides tools to evaluate and measure the quality of language model outputs using various metrics like correctness, relevance, faithfulness, and semantic similarity. It integrates with LangChain4j and supports fluent test assertions for RAG pipelines.
+Rage4J provides tools to evaluate and measure the quality of language model outputs using various metrics like correctness, relevance, faithfulness, semantic similarity, and tool call accuracy. It integrates with LangChain4j and supports fluent test assertions for RAG pipelines.
 
 **Modules:**
 - **rage4j** - Core evaluation library with evaluators and model classes
@@ -96,6 +96,22 @@ rageAssert.given()
     .then()
     .assertAnswerCorrectness(0.8);
 ```
+
+### Tool Call Assertions
+
+```java
+rageAssert.given()
+    .question("Wie wird das Wetter morgen in Berlin?")
+    .expectedToolCall(WeatherTools::getWeather)
+    .withArgument("city", "Berlin")
+    .withArgument("day", "tomorrow")
+    .when()
+    .answerFrom(assistant::chat)
+    .then()
+    .assertToolCallAccuracy(1.0);
+```
+
+`expectedToolCall(...)` accepts a tool name or a method reference to a `@Tool`-annotated method; `withArgument`/`withArguments`/`withArgumentsJson` merge arguments into the most recently declared expected tool call. `answerFrom` runs the LangChain4j AI service once and records both the answer and the tool calls it performed. Besides `assertToolCallAccuracy(minValue)`, `assertToolCallOrder()`, `assertNoToolCall()`, and `assertNoUnexpectedToolCalls()` are available.
 
 ### HTML evaluation report for Jenkins
 

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
@@ -10,6 +10,7 @@ import dev.rage4j.asserts.exception.Rage4JRelevanceException;
 import dev.rage4j.asserts.exception.Rage4JRefusalException;
 import dev.rage4j.asserts.exception.Rage4JRougeScoreException;
 import dev.rage4j.asserts.exception.Rage4JSimilarityException;
+import dev.rage4j.asserts.exception.Rage4JToolCallException;
 import dev.rage4j.evaluation.Evaluation;
 import dev.rage4j.evaluation.answercorrectness.AnswerCorrectnessEvaluator;
 import dev.rage4j.evaluation.answerrelevance.embedding.AnswerRelevanceEmbeddingEvaluator;
@@ -22,13 +23,16 @@ import dev.rage4j.evaluation.bias.implicitexplicit.support.ImplicitExplicitTempl
 import dev.rage4j.evaluation.bias.refusal.RefusalEvaluator;
 import dev.rage4j.evaluation.faithfulness.FaithfulnessEvaluator;
 import dev.rage4j.evaluation.rougescore.RougeScoreEvaluator;
+import dev.rage4j.evaluation.toolcall.ToolCallAccuracyEvaluator;
 import dev.rage4j.model.EvaluationAggregation;
 import dev.rage4j.model.Sample;
+import dev.rage4j.model.ToolCall;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -173,6 +177,104 @@ public class RageAssertTestCaseAssertions
 			handleAssertionFailure(message, "ROUGE Score", () -> new Rage4JRougeScoreException(message));
 		}
 		return AssertionEvaluation.from(evaluation, this);
+	}
+
+	public AssertionEvaluation assertToolCallAccuracy(double minValue)
+	{
+		ToolCallAccuracyEvaluator evaluator = new ToolCallAccuracyEvaluator();
+		Evaluation evaluation = evaluator.evaluate(sample);
+		boolean passed = minValue <= evaluation.getValue();
+		collectEvaluation(evaluation);
+		if (!passed)
+		{
+			String message = MINVALUE + evaluation.getValue() + " expected tool calls: " + sample.getExpectedToolCalls() + " actual tool calls: " + sample.getToolCalls();
+			handleAssertionFailure(message, "Tool Call Accuracy", () -> new Rage4JToolCallException(message));
+		}
+		return AssertionEvaluation.from(evaluation, this);
+	}
+
+	public AssertionEvaluation assertToolCallOrder()
+	{
+		List<ToolCall> expectedToolCalls = sample.getExpectedToolCallsOrFail();
+		List<ToolCall> actualToolCalls = sample.getToolCallsOrFail();
+		boolean passed = isOrderedSubsequence(expectedToolCalls, actualToolCalls);
+		Evaluation evaluation = new Evaluation("Tool Call Order", passed ? 1.0 : 0.0);
+		collectEvaluation(evaluation);
+		if (!passed)
+		{
+			String message = "Expected tool calls were not performed in the expected order! Expected: " + expectedToolCalls + " actual: " + actualToolCalls;
+			handleAssertionFailure(message, "Tool Call Order", () -> new Rage4JToolCallException(message));
+		}
+		return AssertionEvaluation.from(evaluation, this);
+	}
+
+	public AssertionEvaluation assertNoToolCall()
+	{
+		List<ToolCall> actualToolCalls = sample.getToolCallsOrFail();
+		boolean passed = actualToolCalls.isEmpty();
+		Evaluation evaluation = new Evaluation("No Tool Call", passed ? 1.0 : 0.0);
+		collectEvaluation(evaluation);
+		if (!passed)
+		{
+			String message = "Expected no tool call but got: " + actualToolCalls;
+			handleAssertionFailure(message, "No Tool Call", () -> new Rage4JToolCallException(message));
+		}
+		return AssertionEvaluation.from(evaluation, this);
+	}
+
+	public AssertionEvaluation assertNoUnexpectedToolCalls()
+	{
+		List<ToolCall> unexpectedToolCalls = unexpectedToolCalls();
+		boolean passed = unexpectedToolCalls.isEmpty();
+		Evaluation evaluation = new Evaluation("No Unexpected Tool Calls", passed ? 1.0 : 0.0);
+		collectEvaluation(evaluation);
+		if (!passed)
+		{
+			String message = "Tool calls were performed that no expectation covers: " + unexpectedToolCalls;
+			handleAssertionFailure(message, "No Unexpected Tool Calls", () -> new Rage4JToolCallException(message));
+		}
+		return AssertionEvaluation.from(evaluation, this);
+	}
+
+	private List<ToolCall> unexpectedToolCalls()
+	{
+		List<ToolCall> remainingExpected = new ArrayList<>(sample.getExpectedToolCalls());
+		List<ToolCall> unexpected = new ArrayList<>();
+		for (ToolCall actualToolCall : sample.getToolCallsOrFail())
+		{
+			if (!removeFirstMatch(remainingExpected, actualToolCall))
+			{
+				unexpected.add(actualToolCall);
+			}
+		}
+		return unexpected;
+	}
+
+	private boolean removeFirstMatch(List<ToolCall> expectedToolCalls, ToolCall actualToolCall)
+	{
+		Iterator<ToolCall> iterator = expectedToolCalls.iterator();
+		while (iterator.hasNext())
+		{
+			if (iterator.next().matches(actualToolCall))
+			{
+				iterator.remove();
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isOrderedSubsequence(List<ToolCall> expectedToolCalls, List<ToolCall> actualToolCalls)
+	{
+		int expectedIndex = 0;
+		for (ToolCall actualToolCall : actualToolCalls)
+		{
+			if (expectedIndex < expectedToolCalls.size() && expectedToolCalls.get(expectedIndex).matches(actualToolCall))
+			{
+				expectedIndex++;
+			}
+		}
+		return expectedIndex == expectedToolCalls.size();
 	}
 
 	public AssertionEvaluation assertRefusalDisparity()

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseAssertions.java
@@ -27,12 +27,12 @@ import dev.rage4j.evaluation.toolcall.ToolCallAccuracyEvaluator;
 import dev.rage4j.model.EvaluationAggregation;
 import dev.rage4j.model.Sample;
 import dev.rage4j.model.ToolCall;
+import dev.rage4j.model.ToolCallMatching;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -238,30 +238,7 @@ public class RageAssertTestCaseAssertions
 
 	private List<ToolCall> unexpectedToolCalls()
 	{
-		List<ToolCall> remainingExpected = new ArrayList<>(sample.getExpectedToolCalls());
-		List<ToolCall> unexpected = new ArrayList<>();
-		for (ToolCall actualToolCall : sample.getToolCallsOrFail())
-		{
-			if (!removeFirstMatch(remainingExpected, actualToolCall))
-			{
-				unexpected.add(actualToolCall);
-			}
-		}
-		return unexpected;
-	}
-
-	private boolean removeFirstMatch(List<ToolCall> expectedToolCalls, ToolCall actualToolCall)
-	{
-		Iterator<ToolCall> iterator = expectedToolCalls.iterator();
-		while (iterator.hasNext())
-		{
-			if (iterator.next().matches(actualToolCall))
-			{
-				iterator.remove();
-				return true;
-			}
-		}
-		return false;
+		return ToolCallMatching.match(sample.getExpectedToolCalls(), sample.getToolCallsOrFail()).unmatchedActualCalls();
 	}
 
 	private boolean isOrderedSubsequence(List<ToolCall> expectedToolCalls, List<ToolCall> actualToolCalls)

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseBuilder.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseBuilder.java
@@ -2,10 +2,19 @@ package dev.rage4j.asserts;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.rage4j.asserts.toolref.ToolNameResolver;
+import dev.rage4j.asserts.toolref.ToolRef0;
+import dev.rage4j.asserts.toolref.ToolRef1;
+import dev.rage4j.asserts.toolref.ToolRef2;
+import dev.rage4j.asserts.toolref.ToolRef3;
+import dev.rage4j.asserts.toolref.ToolRef4;
 import dev.rage4j.model.Rage4jImage;
+import dev.rage4j.model.ToolArguments;
+import dev.rage4j.model.ToolCall;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class RageAssertTestCaseBuilder
@@ -18,6 +27,7 @@ public class RageAssertTestCaseBuilder
 	private String comparisonGroundTruth;
 	private String comparisonContext;
 	private ImplicitExplicitScenario implicitExplicitScenario;
+	private final List<ToolCall> expectedToolCalls = new ArrayList<>();
 	private final ChatModel judgeChatModel;
 	private final ChatModel evaluatedChatModel;
 	private final EmbeddingModel embeddingModel;
@@ -125,6 +135,68 @@ public class RageAssertTestCaseBuilder
 		return this;
 	}
 
+	public RageAssertTestCaseBuilder expectedToolCall(String toolName)
+	{
+		Objects.requireNonNull(toolName, "toolName");
+		expectedToolCalls.add(ToolCall.of(toolName));
+		return this;
+	}
+
+	public <T> RageAssertTestCaseBuilder expectedToolCall(ToolRef0<T> toolReference)
+	{
+		return expectedToolCall(ToolNameResolver.resolve(toolReference));
+	}
+
+	public <T, A> RageAssertTestCaseBuilder expectedToolCall(ToolRef1<T, A> toolReference)
+	{
+		return expectedToolCall(ToolNameResolver.resolve(toolReference));
+	}
+
+	public <T, A, B> RageAssertTestCaseBuilder expectedToolCall(ToolRef2<T, A, B> toolReference)
+	{
+		return expectedToolCall(ToolNameResolver.resolve(toolReference));
+	}
+
+	public <T, A, B, C> RageAssertTestCaseBuilder expectedToolCall(ToolRef3<T, A, B, C> toolReference)
+	{
+		return expectedToolCall(ToolNameResolver.resolve(toolReference));
+	}
+
+	public <T, A, B, C, D> RageAssertTestCaseBuilder expectedToolCall(ToolRef4<T, A, B, C, D> toolReference)
+	{
+		return expectedToolCall(ToolNameResolver.resolve(toolReference));
+	}
+
+	public RageAssertTestCaseBuilder withArgument(String argumentName, Object value)
+	{
+		Objects.requireNonNull(argumentName, "argumentName");
+		int lastIndex = requireExpectedToolCallIndex();
+		expectedToolCalls.set(lastIndex, expectedToolCalls.get(lastIndex).withArgument(argumentName, value));
+		return this;
+	}
+
+	public RageAssertTestCaseBuilder withArguments(Map<String, Object> arguments)
+	{
+		Objects.requireNonNull(arguments, "arguments");
+		int lastIndex = requireExpectedToolCallIndex();
+		expectedToolCalls.set(lastIndex, expectedToolCalls.get(lastIndex).withArguments(arguments));
+		return this;
+	}
+
+	public RageAssertTestCaseBuilder withArgumentsJson(String argumentsJson)
+	{
+		return withArguments(ToolArguments.fromJson(argumentsJson));
+	}
+
+	private int requireExpectedToolCallIndex()
+	{
+		if (expectedToolCalls.isEmpty())
+		{
+			throw new IllegalStateException("An expectedToolCall must be set before arguments are added.");
+		}
+		return expectedToolCalls.size() - 1;
+	}
+
 	public RageAssertTestCaseGiven when()
 	{
 		return new RageAssertTestCaseGiven(
@@ -136,6 +208,7 @@ public class RageAssertTestCaseBuilder
 			comparisonGroundTruth,
 			comparisonContext,
 			implicitExplicitScenario,
+			List.copyOf(expectedToolCalls),
 			judgeChatModel,
 			evaluatedChatModel,
 			embeddingModel,

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseGiven.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/RageAssertTestCaseGiven.java
@@ -2,8 +2,11 @@ package dev.rage4j.asserts;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.tool.ToolExecution;
 import dev.rage4j.model.Rage4jImage;
 import dev.rage4j.model.Sample;
+import dev.rage4j.model.ToolCall;
 
 import java.util.List;
 import java.util.function.Function;
@@ -18,6 +21,8 @@ public class RageAssertTestCaseGiven
 	private final String comparisonGroundTruth;
 	private final String comparisonContext;
 	private final ImplicitExplicitScenario implicitExplicitScenario;
+	private final List<ToolCall> expectedToolCalls;
+	private List<ToolCall> toolCalls;
 	private String answer;
 	private String comparisonAnswer;
 	private final ChatModel judgeChatModel;
@@ -34,6 +39,7 @@ public class RageAssertTestCaseGiven
 		String comparisonGroundTruth,
 		String comparisonContext,
 		ImplicitExplicitScenario implicitExplicitScenario,
+		List<ToolCall> expectedToolCalls,
 		ChatModel judgeChatModel,
 		ChatModel evaluatedChatModel,
 		EmbeddingModel embeddingModel,
@@ -47,6 +53,7 @@ public class RageAssertTestCaseGiven
 		this.comparisonGroundTruth = comparisonGroundTruth;
 		this.comparisonContext = comparisonContext;
 		this.implicitExplicitScenario = implicitExplicitScenario;
+		this.expectedToolCalls = expectedToolCalls;
 		this.judgeChatModel = judgeChatModel;
 		this.evaluatedChatModel = evaluatedChatModel;
 		this.embeddingModel = embeddingModel;
@@ -81,6 +88,51 @@ public class RageAssertTestCaseGiven
 		return this;
 	}
 
+	/**
+	 * Calls the AI service and records both its answer and the tool calls it
+	 * performed, so that tool call and answer metrics can be asserted on the
+	 * same invocation.
+	 *
+	 * @param callAi
+	 *            The AI service call, returning a LangChain4j {@code Result}.
+	 * @return This instance for chaining.
+	 */
+	public RageAssertTestCaseGiven answerFrom(Function<String, Result<String>> callAi)
+	{
+		Result<String> result = callAi.apply(question);
+		this.answer = result.content();
+		this.toolCalls = ToolExecutionAdapter.toToolCalls(result.toolExecutions());
+		return this;
+	}
+
+	/**
+	 * Records the tool calls LangChain4j reported for the evaluated answer.
+	 *
+	 * @param toolExecutions
+	 *            The tool executions, typically from
+	 *            {@code Result#toolExecutions()}.
+	 * @return This instance for chaining.
+	 */
+	public RageAssertTestCaseGiven toolExecutions(List<ToolExecution> toolExecutions)
+	{
+		this.toolCalls = ToolExecutionAdapter.toToolCalls(toolExecutions);
+		return this;
+	}
+
+	/**
+	 * Records the tool calls performed for the evaluated answer, independently
+	 * of any framework.
+	 *
+	 * @param toolCalls
+	 *            The tool calls the model performed.
+	 * @return This instance for chaining.
+	 */
+	public RageAssertTestCaseGiven toolCalls(List<ToolCall> toolCalls)
+	{
+		this.toolCalls = toolCalls == null ? null : List.copyOf(toolCalls);
+		return this;
+	}
+
 	public RageAssertTestCaseAssertions then()
 	{
 		Sample comparisonSample = buildComparisonSample();
@@ -89,7 +141,9 @@ public class RageAssertTestCaseGiven
 			.withGroundTruth(groundTruth)
 			.withQuestion(question)
 			.withContext(context)
-			.withImages(images);
+			.withImages(images)
+			.withToolCalls(toolCalls)
+			.withExpectedToolCalls(expectedToolCalls == null || expectedToolCalls.isEmpty() ? null : expectedToolCalls);
 		if (comparisonSample != null)
 		{
 			builder.withComparisonSample(comparisonSample);

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/ToolExecutionAdapter.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/ToolExecutionAdapter.java
@@ -1,0 +1,60 @@
+package dev.rage4j.asserts;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecution;
+import dev.rage4j.model.ToolArguments;
+import dev.rage4j.model.ToolCall;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The {@code ToolExecutionAdapter} class converts the tool executions
+ * LangChain4j reports on a {@code Result} into the {@link ToolCall} model
+ * Rage4J evaluates.
+ */
+public final class ToolExecutionAdapter
+{
+	private ToolExecutionAdapter()
+	{
+	}
+
+	/**
+	 * Converts LangChain4j tool executions into tool calls.
+	 *
+	 * @param toolExecutions
+	 *            The tool executions reported by LangChain4j.
+	 * @return The corresponding tool calls, in the same order.
+	 */
+	public static List<ToolCall> toToolCalls(List<ToolExecution> toolExecutions)
+	{
+		Objects.requireNonNull(toolExecutions, "toolExecutions");
+		return toolExecutions.stream()
+			.map(ToolExecutionAdapter::toToolCall)
+			.toList();
+	}
+
+	/**
+	 * Converts a single LangChain4j tool execution into a tool call.
+	 *
+	 * @param toolExecution
+	 *            The tool execution reported by LangChain4j.
+	 * @return The corresponding tool call.
+	 */
+	public static ToolCall toToolCall(ToolExecution toolExecution)
+	{
+		Objects.requireNonNull(toolExecution, "toolExecution");
+		ToolExecutionRequest request = toolExecution.request();
+		return ToolCall.of(request.name(), toArguments(request.arguments()));
+	}
+
+	private static Map<String, Object> toArguments(String argumentsJson)
+	{
+		if (argumentsJson == null || argumentsJson.isBlank())
+		{
+			return Map.of();
+		}
+		return ToolArguments.fromJson(argumentsJson);
+	}
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/exception/Rage4JToolCallException.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/exception/Rage4JToolCallException.java
@@ -1,0 +1,20 @@
+package dev.rage4j.asserts.exception;
+
+public class Rage4JToolCallException extends RuntimeException
+{
+	public Rage4JToolCallException(String message)
+	{
+		super(message);
+	}
+
+	public Rage4JToolCallException(String message, Throwable cause)
+	{
+		super(message, cause);
+	}
+
+	public Rage4JToolCallException()
+	{
+		// empty
+	}
+
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolNameResolver.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolNameResolver.java
@@ -1,0 +1,84 @@
+package dev.rage4j.asserts.toolref;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.rage4j.asserts.exception.Rage4JToolCallException;
+
+import java.io.Serializable;
+import java.lang.reflect.InaccessibleObjectException;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * The {@code ToolNameResolver} class turns a method reference such as
+ * {@code WeatherTools::getWeather} into the tool name the language model
+ * reports.
+ * <p>
+ * Resolving the name from the method rather than from a string keeps
+ * expectations refactoring-safe and honours a {@code @Tool(name = "...")}
+ * override, which a hand-written string would silently get wrong.
+ */
+public final class ToolNameResolver
+{
+	private ToolNameResolver()
+	{
+	}
+
+	/**
+	 * Resolves the tool name of the referenced method.
+	 *
+	 * @param toolReference
+	 *            A method reference pointing at a {@code @Tool} annotated
+	 *            method.
+	 * @return The name the tool is registered under.
+	 * @throws Rage4JToolCallException
+	 *             if the reference cannot be read or does not point at a
+	 *             {@code @Tool} annotated method.
+	 */
+	public static String resolve(Serializable toolReference)
+	{
+		Objects.requireNonNull(toolReference, "toolReference");
+		SerializedLambda serializedLambda = serializedLambda(toolReference);
+		Method toolMethod = toolMethod(serializedLambda, toolReference.getClass().getClassLoader());
+		Tool tool = toolMethod.getAnnotation(Tool.class);
+		if (tool == null)
+		{
+			throw new Rage4JToolCallException(toolMethod + " is not annotated with @Tool and can therefore not be used as an expected tool call");
+		}
+		return tool.name().isEmpty() ? toolMethod.getName() : tool.name();
+	}
+
+	private static SerializedLambda serializedLambda(Serializable toolReference)
+	{
+		try
+		{
+			Method writeReplace = toolReference.getClass().getDeclaredMethod("writeReplace");
+			writeReplace.setAccessible(true);
+			if (writeReplace.invoke(toolReference) instanceof SerializedLambda serializedLambda)
+			{
+				return serializedLambda;
+			}
+			throw new Rage4JToolCallException("Expected a method reference to a @Tool method, but got " + toolReference.getClass());
+		}
+		catch (ReflectiveOperationException | InaccessibleObjectException e)
+		{
+			throw new Rage4JToolCallException("Could not read the tool method reference. Expected tool calls must be declared as a method reference such as WeatherTools::getWeather, and under JPMS the module declaring the tool class must open its package.", e);
+		}
+	}
+
+	private static Method toolMethod(SerializedLambda serializedLambda, ClassLoader classLoader)
+	{
+		String declaringClassName = serializedLambda.getImplClass().replace('/', '.');
+		try
+		{
+			Class<?> declaringClass = Class.forName(declaringClassName, false, classLoader);
+			MethodType methodType = MethodType.fromMethodDescriptorString(serializedLambda.getImplMethodSignature(), classLoader);
+			return declaringClass.getDeclaredMethod(serializedLambda.getImplMethodName(), methodType.parameterArray());
+		}
+		catch (ReflectiveOperationException | IllegalArgumentException | TypeNotPresentException e)
+		{
+			throw new Rage4JToolCallException("Could not resolve the referenced tool method " + declaringClassName + "#" + serializedLambda.getImplMethodName(), e);
+		}
+	}
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef0.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef0.java
@@ -1,0 +1,22 @@
+package dev.rage4j.asserts.toolref;
+
+import java.io.Serializable;
+
+/**
+ * A serializable reference to a tool method taking 0 argument(s), used to
+ * declare an expected tool call by pointing at the method instead of naming it
+ * as a string.
+ * <p>
+ * The functional method returns {@code void} on purpose: a method reference to
+ * a value-returning method is compatible with a void function type, so this
+ * single interface accepts both value-returning and void tool methods, and no
+ * ambiguous overload arises.
+ *
+ * @param <T>
+ *            The type declaring the tool method.
+ */
+@FunctionalInterface
+public interface ToolRef0<T> extends Serializable
+{
+	void invoke(T tools);
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef1.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef1.java
@@ -1,0 +1,24 @@
+package dev.rage4j.asserts.toolref;
+
+import java.io.Serializable;
+
+/**
+ * A serializable reference to a tool method taking 1 argument(s), used to
+ * declare an expected tool call by pointing at the method instead of naming it
+ * as a string.
+ * <p>
+ * The functional method returns {@code void} on purpose: a method reference to
+ * a value-returning method is compatible with a void function type, so this
+ * single interface accepts both value-returning and void tool methods, and no
+ * ambiguous overload arises.
+ *
+ * @param <T>
+ *            The type declaring the tool method.
+ * @param <A>
+ *            The type of the first tool argument.
+ */
+@FunctionalInterface
+public interface ToolRef1<T, A> extends Serializable
+{
+	void invoke(T tools, A a);
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef2.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef2.java
@@ -1,0 +1,26 @@
+package dev.rage4j.asserts.toolref;
+
+import java.io.Serializable;
+
+/**
+ * A serializable reference to a tool method taking 2 argument(s), used to
+ * declare an expected tool call by pointing at the method instead of naming it
+ * as a string.
+ * <p>
+ * The functional method returns {@code void} on purpose: a method reference to
+ * a value-returning method is compatible with a void function type, so this
+ * single interface accepts both value-returning and void tool methods, and no
+ * ambiguous overload arises.
+ *
+ * @param <T>
+ *            The type declaring the tool method.
+ * @param <A>
+ *            The type of the first tool argument.
+ * @param <B>
+ *            The type of the second tool argument.
+ */
+@FunctionalInterface
+public interface ToolRef2<T, A, B> extends Serializable
+{
+	void invoke(T tools, A a, B b);
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef3.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef3.java
@@ -1,0 +1,28 @@
+package dev.rage4j.asserts.toolref;
+
+import java.io.Serializable;
+
+/**
+ * A serializable reference to a tool method taking 3 argument(s), used to
+ * declare an expected tool call by pointing at the method instead of naming it
+ * as a string.
+ * <p>
+ * The functional method returns {@code void} on purpose: a method reference to
+ * a value-returning method is compatible with a void function type, so this
+ * single interface accepts both value-returning and void tool methods, and no
+ * ambiguous overload arises.
+ *
+ * @param <T>
+ *            The type declaring the tool method.
+ * @param <A>
+ *            The type of the first tool argument.
+ * @param <B>
+ *            The type of the second tool argument.
+ * @param <C>
+ *            The type of the third tool argument.
+ */
+@FunctionalInterface
+public interface ToolRef3<T, A, B, C> extends Serializable
+{
+	void invoke(T tools, A a, B b, C c);
+}

--- a/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef4.java
+++ b/dev.rage4j.rage4j-assert/src/main/java/dev/rage4j/asserts/toolref/ToolRef4.java
@@ -1,0 +1,30 @@
+package dev.rage4j.asserts.toolref;
+
+import java.io.Serializable;
+
+/**
+ * A serializable reference to a tool method taking 4 argument(s), used to
+ * declare an expected tool call by pointing at the method instead of naming it
+ * as a string.
+ * <p>
+ * The functional method returns {@code void} on purpose: a method reference to
+ * a value-returning method is compatible with a void function type, so this
+ * single interface accepts both value-returning and void tool methods, and no
+ * ambiguous overload arises.
+ *
+ * @param <T>
+ *            The type declaring the tool method.
+ * @param <A>
+ *            The type of the first tool argument.
+ * @param <B>
+ *            The type of the second tool argument.
+ * @param <C>
+ *            The type of the third tool argument.
+ * @param <D>
+ *            The type of the fourth tool argument.
+ */
+@FunctionalInterface
+public interface ToolRef4<T, A, B, C, D> extends Serializable
+{
+	void invoke(T tools, A a, B b, C c, D d);
+}

--- a/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/RageAssertToolCallTest.java
+++ b/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/RageAssertToolCallTest.java
@@ -145,6 +145,21 @@ class RageAssertToolCallTest
 	}
 
 	@Test
+	void testAssertNoUnexpectedToolCallsMatchesExpectationsOptimally()
+	{
+		rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::getWeather)
+			.expectedToolCall(WeatherTools::getWeather)
+			.withArgument("city", "Berlin")
+			.when()
+			.answer("18 Grad und sonnig.")
+			.toolCalls(List.of(ToolCall.of("getWeather").withArgument("city", "Berlin"), ToolCall.of("getWeather").withArgument("city", "Hamburg")))
+			.then()
+			.assertNoUnexpectedToolCalls();
+	}
+
+	@Test
 	void testAssertToolCallOrderAcceptsInterleavedCalls()
 	{
 		rageAssert.given()

--- a/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/RageAssertToolCallTest.java
+++ b/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/RageAssertToolCallTest.java
@@ -1,0 +1,188 @@
+package dev.rage4j.asserts;
+
+import dev.rage4j.asserts.exception.Rage4JToolCallException;
+import dev.rage4j.asserts.toolref.ToolRef2;
+import dev.rage4j.asserts.toolref.WeatherTools;
+import dev.rage4j.model.ToolCall;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RageAssertToolCallTest
+{
+	private static final String QUESTION = "Wie wird das Wetter morgen in Berlin?";
+
+	private RageAssert rageAssert;
+
+	@BeforeEach
+	void setUp()
+	{
+		rageAssert = new RageAssert(null);
+	}
+
+	@Test
+	void testMethodReferenceExpectationMatchesRecordedToolCall()
+	{
+		double score = rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::getWeather)
+			.withArgument("city", "Berlin")
+			.withArgument("day", "tomorrow")
+			.when()
+			.answer("18 Grad und sonnig.")
+			.toolCalls(List.of(ToolCall.of("getWeather").withArguments(Map.of("city", "Berlin", "day", "tomorrow"))))
+			.then()
+			.assertToolCallAccuracy(1.0)
+			.getEvaluation()
+			.getValue();
+
+		assertEquals(1.0, score, 0.001);
+	}
+
+	@Test
+	void testArgumentsCanBeSuppliedAsMap()
+	{
+		rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::getWeather)
+			.withArguments(Map.of("city", "Berlin"))
+			.when()
+			.answer("18 Grad und sonnig.")
+			.toolCalls(List.of(ToolCall.of("getWeather").withArgument("city", "Berlin")))
+			.then()
+			.assertToolCallAccuracy(1.0);
+	}
+
+	@Test
+	void testArgumentsCanBeSuppliedAsJson()
+	{
+		rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::getWeather)
+			.withArgumentsJson("{\"city\": \"Berlin\", \"day\": \"tomorrow\"}")
+			.when()
+			.answer("18 Grad und sonnig.")
+			.toolCalls(List.of(ToolCall.of("getWeather").withArguments(Map.of("city", "Berlin", "day", "tomorrow"))))
+			.then()
+			.assertToolCallAccuracy(1.0);
+	}
+
+	@Test
+	void testExplicitToolNameOverrideIsResolved()
+	{
+		rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::sendAlert)
+			.when()
+			.answer("Warnung verschickt.")
+			.toolCalls(List.of(ToolCall.of("send_alert")))
+			.then()
+			.assertToolCallAccuracy(1.0);
+	}
+
+	@Test
+	void testWrongArgumentFailsTheAssertion()
+	{
+		assertThrows(Rage4JToolCallException.class, () -> rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::getWeather)
+			.withArgument("city", "Berlin")
+			.when()
+			.answer("18 Grad und sonnig.")
+			.toolCalls(List.of(ToolCall.of("getWeather").withArgument("city", "Hamburg")))
+			.then()
+			.assertToolCallAccuracy(1.0));
+	}
+
+	@Test
+	void testArgumentWithoutExpectedToolCallIsRejected()
+	{
+		assertThrows(IllegalStateException.class, () -> rageAssert.given()
+			.question(QUESTION)
+			.withArgument("city", "Berlin"));
+	}
+
+	@Test
+	void testAssertNoToolCallPassesWhenNothingWasCalled()
+	{
+		rageAssert.given()
+			.question("Wer hat dich gebaut?")
+			.when()
+			.answer("Ein Team von Entwicklern.")
+			.toolCalls(List.of())
+			.then()
+			.assertNoToolCall();
+	}
+
+	@Test
+	void testAssertNoToolCallFailsWhenSomethingWasCalled()
+	{
+		assertThrows(Rage4JToolCallException.class, () -> rageAssert.given()
+			.question("Wer hat dich gebaut?")
+			.when()
+			.answer("Ein Team von Entwicklern.")
+			.toolCalls(List.of(ToolCall.of("getWeather")))
+			.then()
+			.assertNoToolCall());
+	}
+
+	@Test
+	void testAssertNoUnexpectedToolCallsDetectsAdditionalCall()
+	{
+		assertThrows(Rage4JToolCallException.class, () -> rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(WeatherTools::getWeather)
+			.when()
+			.answer("18 Grad und sonnig.")
+			.toolCalls(List.of(ToolCall.of("getWeather"), ToolCall.of("send_alert")))
+			.then()
+			.assertNoUnexpectedToolCalls());
+	}
+
+	@Test
+	void testAssertToolCallOrderAcceptsInterleavedCalls()
+	{
+		rageAssert.given()
+			.question("Storniere meine Buchung.")
+			.expectedToolCall("findCustomer")
+			.expectedToolCall("cancelBooking")
+			.when()
+			.answer("Storniert.")
+			.toolCalls(List.of(ToolCall.of("findCustomer"), ToolCall.of("getTime"), ToolCall.of("cancelBooking")))
+			.then()
+			.assertToolCallOrder();
+	}
+
+	@Test
+	void testAssertToolCallOrderFailsOnSwappedCalls()
+	{
+		assertThrows(Rage4JToolCallException.class, () -> rageAssert.given()
+			.question("Storniere meine Buchung.")
+			.expectedToolCall("findCustomer")
+			.expectedToolCall("cancelBooking")
+			.when()
+			.answer("Storniert.")
+			.toolCalls(List.of(ToolCall.of("cancelBooking"), ToolCall.of("findCustomer")))
+			.then()
+			.assertToolCallOrder());
+	}
+
+	@Test
+	void testMissingToolCallsAreReportedAsMisconfiguration()
+	{
+		ToolRef2<WeatherTools, String, String> toolReference = WeatherTools::getWeather;
+
+		assertThrows(IllegalArgumentException.class, () -> rageAssert.given()
+			.question(QUESTION)
+			.expectedToolCall(toolReference)
+			.when()
+			.answer("18 Grad und sonnig.")
+			.then()
+			.assertToolCallAccuracy(1.0));
+	}
+}

--- a/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/ToolExecutionAdapterTest.java
+++ b/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/ToolExecutionAdapterTest.java
@@ -1,0 +1,53 @@
+package dev.rage4j.asserts;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.ToolExecution;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import dev.rage4j.model.ToolCall;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolExecutionAdapterTest
+{
+	@Test
+	void testConvertsNameAndJsonArguments()
+	{
+		ToolCall toolCall = ToolExecutionAdapter.toToolCall(toolExecution("getWeather", "{\"city\": \"Berlin\", \"day\": \"tomorrow\"}"));
+
+		assertEquals("getWeather", toolCall.name());
+		assertEquals(Map.of("city", "Berlin", "day", "tomorrow"), toolCall.arguments());
+	}
+
+	@Test
+	void testConvertsToolWithoutArguments()
+	{
+		assertTrue(ToolExecutionAdapter.toToolCall(toolExecution("getTime", "{}")).arguments().isEmpty());
+		assertTrue(ToolExecutionAdapter.toToolCall(toolExecution("getTime", "")).arguments().isEmpty());
+		assertTrue(ToolExecutionAdapter.toToolCall(toolExecution("getTime", null)).arguments().isEmpty());
+	}
+
+	@Test
+	void testPreservesOrderOfToolExecutions()
+	{
+		List<ToolCall> toolCalls = ToolExecutionAdapter.toToolCalls(List.of(
+			toolExecution("findCustomer", "{}"),
+			toolExecution("cancelBooking", "{}")));
+
+		assertEquals(List.of("findCustomer", "cancelBooking"), toolCalls.stream().map(ToolCall::name).toList());
+	}
+
+	private ToolExecution toolExecution(String name, String arguments)
+	{
+		return ToolExecution.builder()
+			.request(ToolExecutionRequest.builder().name(name).arguments(arguments).build())
+			.result(ToolExecutionResult.builder().resultText("ok").build())
+			.invocationContext(InvocationContext.builder().build())
+			.build();
+	}
+}

--- a/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/toolref/ToolNameResolverTest.java
+++ b/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/toolref/ToolNameResolverTest.java
@@ -1,0 +1,45 @@
+package dev.rage4j.asserts.toolref;
+
+import dev.rage4j.asserts.exception.Rage4JToolCallException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolNameResolverTest
+{
+	@Test
+	void testResolvesMethodNameOfValueReturningTool()
+	{
+		assertEquals("getWeather", ToolNameResolver.resolve((ToolRef2<WeatherTools, String, String>)WeatherTools::getWeather));
+	}
+
+	@Test
+	void testResolvesMethodNameOfToolWithoutArguments()
+	{
+		assertEquals("getTime", ToolNameResolver.resolve((ToolRef0<WeatherTools>)WeatherTools::getTime));
+	}
+
+	@Test
+	void testResolvesExplicitToolNameOfVoidTool()
+	{
+		assertEquals("send_alert", ToolNameResolver.resolve((ToolRef1<WeatherTools, String>)WeatherTools::sendAlert));
+	}
+
+	@Test
+	void testRejectsMethodWithoutToolAnnotation()
+	{
+		Rage4JToolCallException exception = assertThrows(Rage4JToolCallException.class,
+			() -> ToolNameResolver.resolve((ToolRef1<WeatherTools, String>)WeatherTools::notATool));
+
+		assertTrue(exception.getMessage().contains("@Tool"));
+	}
+
+	@Test
+	void testRejectsNonMethodReferenceLambda()
+	{
+		assertThrows(Rage4JToolCallException.class,
+			() -> ToolNameResolver.resolve((ToolRef0<WeatherTools>)tools -> tools.getTime()));
+	}
+}

--- a/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/toolref/WeatherTools.java
+++ b/dev.rage4j.rage4j-assert/src/test/java/dev/rage4j/asserts/toolref/WeatherTools.java
@@ -1,0 +1,29 @@
+package dev.rage4j.asserts.toolref;
+
+import dev.langchain4j.agent.tool.Tool;
+
+public class WeatherTools
+{
+	@Tool("Returns the weather forecast for a city on a given day")
+	public String getWeather(String city, String day)
+	{
+		return "18C, sunny";
+	}
+
+	@Tool("Returns the current server time")
+	public String getTime()
+	{
+		return "12:00";
+	}
+
+	@Tool(name = "send_alert", value = "Sends a weather alert")
+	public void sendAlert(String city)
+	{
+		// no side effect in tests
+	}
+
+	public String notATool(String city)
+	{
+		return city;
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluator.java
@@ -1,0 +1,91 @@
+package dev.rage4j.evaluation.toolcall;
+
+import dev.rage4j.evaluation.Evaluation;
+import dev.rage4j.evaluation.Evaluator;
+import dev.rage4j.model.Sample;
+import dev.rage4j.model.ToolCall;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * The {@code ToolCallAccuracyEvaluator} class measures how many of the tool
+ * calls a test expects were actually performed by the language model. It
+ * compares the expected calls of a {@link Sample} against the calls the model
+ * reported, without involving a language model itself.
+ * <p>
+ * An expected call matches an actual one when the tool names are equal and
+ * every expected argument is present with an equivalent value. Expected
+ * arguments are therefore a subset of the actual ones, and an expectation
+ * without arguments matches any call of the same name.
+ * <p>
+ * The result is the fraction of expected calls that were matched, between 0 and
+ * 1. Each actual call satisfies at most one expectation, so a model that calls
+ * a tool once cannot satisfy two expectations of it. Additional calls the test
+ * did not expect do not lower the score.
+ */
+public class ToolCallAccuracyEvaluator implements Evaluator
+{
+	private static final String METRIC_NAME = "Tool Call Accuracy";
+	private static final Logger LOG = LoggerFactory.getLogger(ToolCallAccuracyEvaluator.class);
+
+	/**
+	 * Evaluates how many of the expected tool calls the model performed.
+	 *
+	 * @param sample
+	 *            The sample containing both the expected and the actual tool
+	 *            calls.
+	 * @return An Evaluation object containing the tool call accuracy.
+	 * @throws IllegalArgumentException
+	 *             if the sample carries no expected tool calls, or if no actual
+	 *             tool calls were recorded on it.
+	 */
+	@Override
+	public Evaluation evaluate(Sample sample)
+	{
+		if (!sample.hasExpectedToolCalls())
+		{
+			throw new IllegalArgumentException("Sample must have expected tool calls for Tool Call Accuracy evaluation");
+		}
+		if (!sample.hasToolCalls())
+		{
+			throw new IllegalArgumentException("Sample must have recorded tool calls for Tool Call Accuracy evaluation");
+		}
+
+		List<ToolCall> expectedToolCalls = sample.getExpectedToolCalls();
+		List<ToolCall> unmatchedToolCalls = new ArrayList<>(sample.getToolCalls());
+		LOG.info("Evaluating new sample");
+		LOG.info("Expected tool calls: {}", expectedToolCalls);
+		LOG.info("Actual tool calls: {}", unmatchedToolCalls);
+
+		int matches = 0;
+		for (ToolCall expectedToolCall : expectedToolCalls)
+		{
+			if (removeFirstMatch(unmatchedToolCalls, expectedToolCall))
+			{
+				matches++;
+			}
+		}
+
+		double score = (double)matches / expectedToolCalls.size();
+		LOG.info("Tool Call Accuracy: {}", score);
+		return new Evaluation(METRIC_NAME, score);
+	}
+
+	private boolean removeFirstMatch(List<ToolCall> actualToolCalls, ToolCall expectedToolCall)
+	{
+		Iterator<ToolCall> iterator = actualToolCalls.iterator();
+		while (iterator.hasNext())
+		{
+			if (expectedToolCall.matches(iterator.next()))
+			{
+				iterator.remove();
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluator.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluator.java
@@ -4,11 +4,11 @@ import dev.rage4j.evaluation.Evaluation;
 import dev.rage4j.evaluation.Evaluator;
 import dev.rage4j.model.Sample;
 import dev.rage4j.model.ToolCall;
+import dev.rage4j.model.ToolCallMatchResult;
+import dev.rage4j.model.ToolCallMatching;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -56,36 +56,14 @@ public class ToolCallAccuracyEvaluator implements Evaluator
 		}
 
 		List<ToolCall> expectedToolCalls = sample.getExpectedToolCalls();
-		List<ToolCall> unmatchedToolCalls = new ArrayList<>(sample.getToolCalls());
+		List<ToolCall> actualToolCalls = sample.getToolCalls();
 		LOG.info("Evaluating new sample");
 		LOG.info("Expected tool calls: {}", expectedToolCalls);
-		LOG.info("Actual tool calls: {}", unmatchedToolCalls);
+		LOG.info("Actual tool calls: {}", actualToolCalls);
 
-		int matches = 0;
-		for (ToolCall expectedToolCall : expectedToolCalls)
-		{
-			if (removeFirstMatch(unmatchedToolCalls, expectedToolCall))
-			{
-				matches++;
-			}
-		}
-
-		double score = (double)matches / expectedToolCalls.size();
+		ToolCallMatchResult matchResult = ToolCallMatching.match(expectedToolCalls, actualToolCalls);
+		double score = (double)matchResult.matchedExpectedCalls() / expectedToolCalls.size();
 		LOG.info("Tool Call Accuracy: {}", score);
 		return new Evaluation(METRIC_NAME, score);
-	}
-
-	private boolean removeFirstMatch(List<ToolCall> actualToolCalls, ToolCall expectedToolCall)
-	{
-		Iterator<ToolCall> iterator = actualToolCalls.iterator();
-		while (iterator.hasNext())
-		{
-			if (expectedToolCall.matches(iterator.next()))
-			{
-				iterator.remove();
-				return true;
-			}
-		}
-		return false;
 	}
 }

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Sample.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/Sample.java
@@ -27,6 +27,8 @@ public class Sample implements Serializable
 	protected String context;
 	protected List<Rage4jImage> images;
 	protected Sample comparisonSample;
+	protected List<ToolCall> toolCalls;
+	protected List<ToolCall> expectedToolCalls;
 
 	private Sample(SampleBuilder builder)
 	{
@@ -36,6 +38,8 @@ public class Sample implements Serializable
 		this.context = builder.context;
 		this.images = builder.images == null ? null : List.copyOf(builder.images);
 		this.comparisonSample = builder.comparisonSample;
+		this.toolCalls = builder.toolCalls == null ? null : List.copyOf(builder.toolCalls);
+		this.expectedToolCalls = builder.expectedToolCalls == null ? null : List.copyOf(builder.expectedToolCalls);
 	}
 
 	public String getQuestion()
@@ -163,6 +167,44 @@ public class Sample implements Serializable
 		return hasComparisonSample();
 	}
 
+	public List<ToolCall> getToolCalls()
+	{
+		return toolCalls == null ? Collections.emptyList() : toolCalls;
+	}
+
+	public List<ToolCall> getToolCallsOrFail()
+	{
+		if (Objects.isNull(toolCalls))
+		{
+			throwAttributeNotFound("toolCalls");
+		}
+		return toolCalls;
+	}
+
+	public boolean hasToolCalls()
+	{
+		return toolCalls != null;
+	}
+
+	public List<ToolCall> getExpectedToolCalls()
+	{
+		return expectedToolCalls == null ? Collections.emptyList() : expectedToolCalls;
+	}
+
+	public List<ToolCall> getExpectedToolCallsOrFail()
+	{
+		if (Objects.isNull(expectedToolCalls))
+		{
+			throwAttributeNotFound("expectedToolCalls");
+		}
+		return expectedToolCalls;
+	}
+
+	public boolean hasExpectedToolCalls()
+	{
+		return expectedToolCalls != null && !expectedToolCalls.isEmpty();
+	}
+
 	@Override
 	public boolean equals(Object o)
 	{
@@ -180,13 +222,15 @@ public class Sample implements Serializable
 			&& Objects.equals(groundTruth, sample.groundTruth)
 			&& Objects.equals(context, sample.context)
 			&& Objects.equals(images, sample.images)
-			&& Objects.equals(comparisonSample, sample.comparisonSample);
+			&& Objects.equals(comparisonSample, sample.comparisonSample)
+			&& Objects.equals(toolCalls, sample.toolCalls)
+			&& Objects.equals(expectedToolCalls, sample.expectedToolCalls);
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(question, answer, groundTruth, context, images, comparisonSample);
+		return Objects.hash(question, answer, groundTruth, context, images, comparisonSample, toolCalls, expectedToolCalls);
 	}
 
 	private void throwAttributeNotFound(String attribute)
@@ -207,6 +251,8 @@ public class Sample implements Serializable
 		private String context;
 		private List<Rage4jImage> images;
 		private Sample comparisonSample;
+		private List<ToolCall> toolCalls;
+		private List<ToolCall> expectedToolCalls;
 
 		public SampleBuilder withQuestion(String question)
 		{
@@ -264,6 +310,18 @@ public class Sample implements Serializable
 		public SampleBuilder withControlSample(Sample controlSample)
 		{
 			return withComparisonSample(controlSample);
+		}
+
+		public SampleBuilder withToolCalls(List<ToolCall> toolCalls)
+		{
+			this.toolCalls = toolCalls == null ? null : new ArrayList<>(toolCalls);
+			return this;
+		}
+
+		public SampleBuilder withExpectedToolCalls(List<ToolCall> expectedToolCalls)
+		{
+			this.expectedToolCalls = expectedToolCalls == null ? null : new ArrayList<>(expectedToolCalls);
+			return this;
 		}
 
 		public Sample build()

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolArguments.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolArguments.java
@@ -1,0 +1,108 @@
+package dev.rage4j.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The {@code ToolArguments} class provides the parsing and comparison of tool
+ * call arguments.
+ * <p>
+ * Both the arguments reported by a language model and the ones a test declares
+ * as expected pass through this class, so that they are always compared in the
+ * same representation.
+ */
+public final class ToolArguments
+{
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private ToolArguments()
+	{
+	}
+
+	/**
+	 * Parses a JSON object into an argument map. Language models report tool
+	 * call arguments as a JSON object, so this is the canonical way to turn a
+	 * recorded call into a comparable map.
+	 *
+	 * @param json
+	 *            A JSON object holding the arguments keyed by parameter name.
+	 * @return The parsed arguments.
+	 * @throws IllegalArgumentException
+	 *             if the input is not valid JSON or not a JSON object.
+	 */
+	public static Map<String, Object> fromJson(String json)
+	{
+		Objects.requireNonNull(json, "json");
+		try
+		{
+			JsonNode node = OBJECT_MAPPER.readTree(json);
+			if (!node.isObject())
+			{
+				throw new IllegalArgumentException("Tool arguments must be a JSON object but were: " + json);
+			}
+			return OBJECT_MAPPER.convertValue(node, new TypeReference<LinkedHashMap<String, Object>>()
+			{
+			});
+		}
+		catch (JsonProcessingException e)
+		{
+			throw new IllegalArgumentException("Tool arguments are not valid JSON: " + json, e);
+		}
+	}
+
+	/**
+	 * Checks whether every expected argument is present in the actual arguments
+	 * with an equivalent value. Additional actual arguments are ignored, so an
+	 * empty expectation matches any call.
+	 * <p>
+	 * Top level numbers are compared by numeric value rather than by type,
+	 * because the same argument arrives as an {@code Integer} from a JSON
+	 * payload and as a {@code Long} from a hand-written expectation. Values
+	 * nested inside a map or list are compared with {@code equals}, so numbers
+	 * within them must also match in type.
+	 *
+	 * @param expected
+	 *            The arguments the call is expected to carry.
+	 * @param actual
+	 *            The arguments the call actually carried.
+	 * @return {@code true} if the actual arguments satisfy the expectation.
+	 */
+	public static boolean matches(Map<String, Object> expected, Map<String, Object> actual)
+	{
+		Objects.requireNonNull(expected, "expected");
+		Objects.requireNonNull(actual, "actual");
+		for (Map.Entry<String, Object> expectedArgument : expected.entrySet())
+		{
+			if (!actual.containsKey(expectedArgument.getKey()))
+			{
+				return false;
+			}
+			if (!valuesMatch(expectedArgument.getValue(), actual.get(expectedArgument.getKey())))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean valuesMatch(Object expected, Object actual)
+	{
+		if (expected instanceof Number expectedNumber && actual instanceof Number actualNumber)
+		{
+			return toBigDecimal(expectedNumber).compareTo(toBigDecimal(actualNumber)) == 0;
+		}
+		return Objects.equals(expected, actual);
+	}
+
+	private static BigDecimal toBigDecimal(Number number)
+	{
+		return new BigDecimal(number.toString());
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCall.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCall.java
@@ -1,8 +1,10 @@
 package dev.rage4j.model;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -11,7 +13,8 @@ import java.util.Objects;
  * one that a language model actually performed or one that a test expects it to
  * perform.
  * <p>
- * Instances are immutable; {@link #withArgument(String, Object)} and
+ * Instances are deeply immutable: nested maps and lists in the arguments are
+ * copied and wrapped as well. {@link #withArgument(String, Object)} and
  * {@link #withArguments(Map)} return new instances with the additional
  * arguments merged in.
  * <p>
@@ -30,7 +33,31 @@ public record ToolCall(String name, Map<String, Object> arguments) implements Se
 	{
 		Objects.requireNonNull(name, "name");
 		Objects.requireNonNull(arguments, "arguments");
-		arguments = Collections.unmodifiableMap(new LinkedHashMap<>(arguments));
+		arguments = immutableCopy(arguments);
+	}
+
+	private static Map<String, Object> immutableCopy(Map<String, Object> arguments)
+	{
+		Map<String, Object> copy = new LinkedHashMap<>();
+		arguments.forEach((argumentName, value) -> copy.put(argumentName, immutableValue(value)));
+		return Collections.unmodifiableMap(copy);
+	}
+
+	private static Object immutableValue(Object value)
+	{
+		if (value instanceof Map<?, ?> nestedMap)
+		{
+			Map<Object, Object> copy = new LinkedHashMap<>();
+			nestedMap.forEach((key, nestedValue) -> copy.put(key, immutableValue(nestedValue)));
+			return Collections.unmodifiableMap(copy);
+		}
+		if (value instanceof List<?> nestedList)
+		{
+			List<Object> copy = new ArrayList<>(nestedList.size());
+			nestedList.forEach(element -> copy.add(immutableValue(element)));
+			return Collections.unmodifiableList(copy);
+		}
+		return value;
 	}
 
 	/**

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCall.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCall.java
@@ -1,0 +1,111 @@
+package dev.rage4j.model;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The {@code ToolCall} record represents a single invocation of a tool, either
+ * one that a language model actually performed or one that a test expects it to
+ * perform.
+ * <p>
+ * Instances are immutable; {@link #withArgument(String, Object)} and
+ * {@link #withArguments(Map)} return new instances with the additional
+ * arguments merged in.
+ * <p>
+ * When used as an expectation, the arguments are matched as a subset of the
+ * actual ones, so a {@code ToolCall} without any arguments matches every actual
+ * call of the same name.
+ *
+ * @param name
+ *            The name of the tool, as reported by the model.
+ * @param arguments
+ *            The arguments the tool was called with, keyed by parameter name.
+ */
+public record ToolCall(String name, Map<String, Object> arguments) implements Serializable
+{
+	public ToolCall
+	{
+		Objects.requireNonNull(name, "name");
+		Objects.requireNonNull(arguments, "arguments");
+		arguments = Collections.unmodifiableMap(new LinkedHashMap<>(arguments));
+	}
+
+	/**
+	 * Creates a tool call without arguments.
+	 *
+	 * @param name
+	 *            The name of the tool.
+	 * @return A new {@code ToolCall} carrying no arguments.
+	 */
+	public static ToolCall of(String name)
+	{
+		return new ToolCall(name, Map.of());
+	}
+
+	/**
+	 * Creates a tool call with the given arguments.
+	 *
+	 * @param name
+	 *            The name of the tool.
+	 * @param arguments
+	 *            The arguments the tool was called with.
+	 * @return A new {@code ToolCall} carrying the given arguments.
+	 */
+	public static ToolCall of(String name, Map<String, Object> arguments)
+	{
+		return new ToolCall(name, arguments);
+	}
+
+	/**
+	 * Returns a copy of this tool call with one additional argument. An
+	 * existing argument of the same name is overwritten.
+	 *
+	 * @param argumentName
+	 *            The parameter name of the argument.
+	 * @param value
+	 *            The argument value, which may be {@code null}.
+	 * @return A new {@code ToolCall} with the argument merged in.
+	 */
+	public ToolCall withArgument(String argumentName, Object value)
+	{
+		Objects.requireNonNull(argumentName, "argumentName");
+		Map<String, Object> merged = new LinkedHashMap<>(arguments);
+		merged.put(argumentName, value);
+		return new ToolCall(name, merged);
+	}
+
+	/**
+	 * Returns a copy of this tool call with the given arguments merged in.
+	 * Existing arguments of the same name are overwritten.
+	 *
+	 * @param additionalArguments
+	 *            The arguments to merge in.
+	 * @return A new {@code ToolCall} with the arguments merged in.
+	 */
+	public ToolCall withArguments(Map<String, Object> additionalArguments)
+	{
+		Objects.requireNonNull(additionalArguments, "additionalArguments");
+		Map<String, Object> merged = new LinkedHashMap<>(arguments);
+		merged.putAll(additionalArguments);
+		return new ToolCall(name, merged);
+	}
+
+	/**
+	 * Checks whether an actual tool call satisfies this expectation. The names
+	 * must be equal and every expected argument must be present with an
+	 * equivalent value, so an expectation without arguments matches any call of
+	 * the same name.
+	 *
+	 * @param actualToolCall
+	 *            The call the language model actually performed.
+	 * @return {@code true} if the actual call satisfies this expectation.
+	 */
+	public boolean matches(ToolCall actualToolCall)
+	{
+		Objects.requireNonNull(actualToolCall, "actualToolCall");
+		return name.equals(actualToolCall.name()) && ToolArguments.matches(arguments, actualToolCall.arguments());
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCallMatchResult.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCallMatchResult.java
@@ -1,0 +1,20 @@
+package dev.rage4j.model;
+
+import java.util.List;
+
+/**
+ * The outcome of matching expected tool calls against the ones a language model
+ * actually performed.
+ *
+ * @param matchedExpectedCalls
+ *            How many of the expected calls were satisfied.
+ * @param unmatchedActualCalls
+ *            The actual calls that no expectation covers.
+ */
+public record ToolCallMatchResult(int matchedExpectedCalls, List<ToolCall> unmatchedActualCalls)
+{
+	public ToolCallMatchResult
+	{
+		unmatchedActualCalls = List.copyOf(unmatchedActualCalls);
+	}
+}

--- a/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCallMatching.java
+++ b/dev.rage4j.rage4j/src/main/java/dev/rage4j/model/ToolCallMatching.java
@@ -1,0 +1,83 @@
+package dev.rage4j.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The {@code ToolCallMatching} class pairs expected tool calls with the ones a
+ * language model actually performed, so that each actual call satisfies at most
+ * one expectation.
+ * <p>
+ * The pairing is a maximum bipartite matching, computed with Kuhn's algorithm.
+ * Taking the first match for each expectation in turn would under-report: an
+ * expectation without arguments matches any call of its name and would consume
+ * the very call that a more specific expectation of the same tool needs, even
+ * though a pairing satisfying both exists.
+ */
+public final class ToolCallMatching
+{
+	private static final int UNMATCHED = -1;
+
+	private ToolCallMatching()
+	{
+	}
+
+	/**
+	 * Pairs the expected tool calls with the actual ones.
+	 *
+	 * @param expectedToolCalls
+	 *            The tool calls a test expects.
+	 * @param actualToolCalls
+	 *            The tool calls the language model performed.
+	 * @return How many expectations were satisfied, and which actual calls no
+	 *         expectation covers.
+	 */
+	public static ToolCallMatchResult match(List<ToolCall> expectedToolCalls, List<ToolCall> actualToolCalls)
+	{
+		Objects.requireNonNull(expectedToolCalls, "expectedToolCalls");
+		Objects.requireNonNull(actualToolCalls, "actualToolCalls");
+
+		int[] expectationForActualCall = new int[actualToolCalls.size()];
+		Arrays.fill(expectationForActualCall, UNMATCHED);
+
+		int matchedExpectedCalls = 0;
+		for (int expectedIndex = 0; expectedIndex < expectedToolCalls.size(); expectedIndex++)
+		{
+			if (assign(expectedIndex, expectedToolCalls, actualToolCalls, expectationForActualCall, new boolean[actualToolCalls.size()]))
+			{
+				matchedExpectedCalls++;
+			}
+		}
+
+		List<ToolCall> unmatchedActualCalls = new ArrayList<>();
+		for (int actualIndex = 0; actualIndex < expectationForActualCall.length; actualIndex++)
+		{
+			if (expectationForActualCall[actualIndex] == UNMATCHED)
+			{
+				unmatchedActualCalls.add(actualToolCalls.get(actualIndex));
+			}
+		}
+		return new ToolCallMatchResult(matchedExpectedCalls, unmatchedActualCalls);
+	}
+
+	private static boolean assign(int expectedIndex, List<ToolCall> expectedToolCalls, List<ToolCall> actualToolCalls, int[] expectationForActualCall, boolean[] visitedActualCalls)
+	{
+		for (int actualIndex = 0; actualIndex < actualToolCalls.size(); actualIndex++)
+		{
+			if (visitedActualCalls[actualIndex] || !expectedToolCalls.get(expectedIndex).matches(actualToolCalls.get(actualIndex)))
+			{
+				continue;
+			}
+			visitedActualCalls[actualIndex] = true;
+			if (expectationForActualCall[actualIndex] == UNMATCHED
+				|| assign(expectationForActualCall[actualIndex], expectedToolCalls, actualToolCalls, expectationForActualCall, visitedActualCalls))
+			{
+				expectationForActualCall[actualIndex] = expectedIndex;
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluatorTest.java
@@ -109,6 +109,26 @@ class ToolCallAccuracyEvaluatorTest
 	}
 
 	@Test
+	void testUnconstrainedExpectationDoesNotConsumeTheCallASpecificOneNeeds()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather"), ToolCall.of("getWeather").withArgument("city", "Berlin")),
+			List.of(ToolCall.of("getWeather").withArgument("city", "Berlin"), ToolCall.of("getWeather").withArgument("city", "Hamburg")));
+
+		assertEquals(1.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testOverlappingExpectationsAreMatchedOptimally()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("search").withArgument("query", "x"), ToolCall.of("search").withArguments(Map.of("query", "x", "limit", 10))),
+			List.of(ToolCall.of("search").withArguments(Map.of("query", "x", "limit", 10)), ToolCall.of("search").withArguments(Map.of("query", "x", "limit", 5))));
+
+		assertEquals(1.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
 	void testNoActualToolCallsScoresZero()
 	{
 		Sample sample = sample(List.of(ToolCall.of("getWeather")), List.of());

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluatorTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/evaluation/toolcall/ToolCallAccuracyEvaluatorTest.java
@@ -1,0 +1,146 @@
+package dev.rage4j.evaluation.toolcall;
+
+import dev.rage4j.LoggingTestWatcher;
+import dev.rage4j.evaluation.Evaluation;
+import dev.rage4j.model.Sample;
+import dev.rage4j.model.ToolCall;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(LoggingTestWatcher.class)
+class ToolCallAccuracyEvaluatorTest
+{
+	private ToolCallAccuracyEvaluator evaluator;
+
+	@BeforeEach
+	void setUp()
+	{
+		evaluator = new ToolCallAccuracyEvaluator();
+	}
+
+	@Test
+	void testExactMatchScoresOne()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather").withArgument("city", "Berlin")),
+			List.of(ToolCall.of("getWeather").withArgument("city", "Berlin")));
+
+		Evaluation result = evaluator.evaluate(sample);
+
+		assertEquals("Tool Call Accuracy", result.getName());
+		assertEquals(1.0, result.getValue(), 0.001);
+	}
+
+	@Test
+	void testHalfOfTheExpectedCallsScoresOneHalf()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("findCustomer"), ToolCall.of("cancelBooking")),
+			List.of(ToolCall.of("findCustomer")));
+
+		assertEquals(0.5, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testDifferentArgumentValueScoresZero()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather").withArgument("city", "Berlin")),
+			List.of(ToolCall.of("getWeather").withArgument("city", "Hamburg")));
+
+		assertEquals(0.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testExpectedWithoutArgumentsMatchesOnNameAlone()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather")),
+			List.of(ToolCall.of("getWeather").withArgument("city", "Berlin")));
+
+		assertEquals(1.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testExpectedArgumentsMayBeASubsetOfTheActualOnes()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather").withArgument("city", "Berlin")),
+			List.of(ToolCall.of("getWeather").withArguments(Map.of("city", "Berlin", "day", "tomorrow"))));
+
+		assertEquals(1.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testEquivalentNumbersMatchAcrossTypes()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("listBookings").withArgument("limit", 3)),
+			List.of(ToolCall.of("listBookings").withArgument("limit", 3L)));
+
+		assertEquals(1.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testUnexpectedAdditionalCallsDoNotLowerTheScore()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather")),
+			List.of(ToolCall.of("getWeather"), ToolCall.of("sendMail")));
+
+		assertEquals(1.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testEachExpectedCallIsMatchedAtMostOnce()
+	{
+		Sample sample = sample(
+			List.of(ToolCall.of("getWeather"), ToolCall.of("getWeather")),
+			List.of(ToolCall.of("getWeather")));
+
+		assertEquals(0.5, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testNoActualToolCallsScoresZero()
+	{
+		Sample sample = sample(List.of(ToolCall.of("getWeather")), List.of());
+
+		assertEquals(0.0, evaluator.evaluate(sample).getValue(), 0.001);
+	}
+
+	@Test
+	void testMissingExpectedToolCallsThrowsException()
+	{
+		Sample sample = Sample.builder()
+			.withToolCalls(List.of(ToolCall.of("getWeather")))
+			.build();
+
+		assertThrows(IllegalArgumentException.class, () -> evaluator.evaluate(sample));
+	}
+
+	@Test
+	void testMissingActualToolCallsThrowsException()
+	{
+		Sample sample = Sample.builder()
+			.withExpectedToolCalls(List.of(ToolCall.of("getWeather")))
+			.build();
+
+		assertThrows(IllegalArgumentException.class, () -> evaluator.evaluate(sample));
+	}
+
+	private Sample sample(List<ToolCall> expected, List<ToolCall> actual)
+	{
+		return Sample.builder()
+			.withExpectedToolCalls(expected)
+			.withToolCalls(actual)
+			.build();
+	}
+}

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolArgumentsTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolArgumentsTest.java
@@ -46,6 +46,19 @@ class ToolArgumentsTest
 	}
 
 	@Test
+	void testFromJsonRejectsEmptyInput()
+	{
+		assertThrows(IllegalArgumentException.class, () -> ToolArguments.fromJson(""));
+		assertThrows(IllegalArgumentException.class, () -> ToolArguments.fromJson("   "));
+	}
+
+	@Test
+	void testFromJsonRejectsJsonNullLiteral()
+	{
+		assertThrows(IllegalArgumentException.class, () -> ToolArguments.fromJson("null"));
+	}
+
+	@Test
 	void testFromJsonRejectsNull()
 	{
 		assertThrows(NullPointerException.class, () -> ToolArguments.fromJson(null));

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolArgumentsTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolArgumentsTest.java
@@ -1,0 +1,81 @@
+package dev.rage4j.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolArgumentsTest
+{
+	@Test
+	void testFromJsonParsesFlatObject()
+	{
+		Map<String, Object> arguments = ToolArguments.fromJson("{\"city\": \"Berlin\", \"day\": \"tomorrow\"}");
+
+		assertEquals(Map.of("city", "Berlin", "day", "tomorrow"), arguments);
+	}
+
+	@Test
+	void testFromJsonParsesNestedObject()
+	{
+		Map<String, Object> arguments = ToolArguments.fromJson("{\"filter\": {\"country\": \"DE\"}}");
+
+		assertEquals(Map.of("country", "DE"), arguments.get("filter"));
+	}
+
+	@Test
+	void testFromJsonParsesEmptyObject()
+	{
+		assertTrue(ToolArguments.fromJson("{}").isEmpty());
+	}
+
+	@Test
+	void testFromJsonRejectsMalformedJson()
+	{
+		assertThrows(IllegalArgumentException.class, () -> ToolArguments.fromJson("{\"city\": "));
+	}
+
+	@Test
+	void testFromJsonRejectsNonObjectJson()
+	{
+		assertThrows(IllegalArgumentException.class, () -> ToolArguments.fromJson("[\"Berlin\"]"));
+	}
+
+	@Test
+	void testFromJsonRejectsNull()
+	{
+		assertThrows(NullPointerException.class, () -> ToolArguments.fromJson(null));
+	}
+
+	@Test
+	void testMatchesTreatsEquivalentNumbersAsEqual()
+	{
+		assertTrue(ToolArguments.matches(Map.of("count", 3), Map.of("count", 3L)));
+		assertTrue(ToolArguments.matches(Map.of("ratio", 1.50), Map.of("ratio", 1.5)));
+	}
+
+	@Test
+	void testNestedValuesAreComparedWithoutNumericNormalisation()
+	{
+		assertTrue(ToolArguments.matches(Map.of("filter", Map.of("limit", 3)), Map.of("filter", Map.of("limit", 3))));
+		assertFalse(ToolArguments.matches(Map.of("filter", Map.of("limit", 3)), Map.of("filter", Map.of("limit", 3L))));
+	}
+
+	@Test
+	void testMatchesRequiresExpectedEntriesToBePresent()
+	{
+		assertTrue(ToolArguments.matches(Map.of("city", "Berlin"), Map.of("city", "Berlin", "day", "tomorrow")));
+		assertTrue(ToolArguments.matches(Map.of(), Map.of("city", "Berlin")));
+	}
+
+	@Test
+	void testMatchesFailsOnDifferentValue()
+	{
+		assertFalse(ToolArguments.matches(Map.of("city", "Berlin"), Map.of("city", "Hamburg")));
+		assertFalse(ToolArguments.matches(Map.of("city", "Berlin"), Map.of("day", "tomorrow")));
+	}
+}

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolCallTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolCallTest.java
@@ -4,6 +4,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,6 +61,38 @@ class ToolCallTest
 		ToolCall toolCall = ToolCall.of("getWeather").withArgument("city", "Berlin");
 
 		assertThrows(UnsupportedOperationException.class, () -> toolCall.arguments().put("day", "tomorrow"));
+	}
+
+	@Test
+	void testNestedArgumentsAreCopiedDefensively()
+	{
+		Map<String, Object> nestedFilter = new HashMap<>();
+		nestedFilter.put("limit", 3);
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("filter", nestedFilter);
+
+		ToolCall toolCall = ToolCall.of("search", arguments);
+		nestedFilter.put("limit", 99);
+
+		assertEquals(Map.of("limit", 3), toolCall.arguments().get("filter"));
+	}
+
+	@Test
+	void testNestedMapArgumentsAreImmutable()
+	{
+		ToolCall toolCall = ToolCall.of("search", Map.of("filter", new HashMap<>(Map.of("limit", 3))));
+
+		Map<?, ?> filter = (Map<?, ?>)toolCall.arguments().get("filter");
+		assertThrows(UnsupportedOperationException.class, () -> ((Map<Object, Object>)filter).put("limit", 99));
+	}
+
+	@Test
+	void testNestedListArgumentsAreImmutable()
+	{
+		ToolCall toolCall = ToolCall.of("search", Map.of("tags", new ArrayList<>(List.of("a", "b"))));
+
+		List<?> tags = (List<?>)toolCall.arguments().get("tags");
+		assertThrows(UnsupportedOperationException.class, () -> ((List<Object>)tags).add("c"));
 	}
 
 	@Test

--- a/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolCallTest.java
+++ b/dev.rage4j.rage4j/src/test/java/dev/rage4j/model/ToolCallTest.java
@@ -1,0 +1,87 @@
+package dev.rage4j.model;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolCallTest
+{
+	@Test
+	void testOfNameHasNoArguments()
+	{
+		ToolCall toolCall = ToolCall.of("getWeather");
+
+		assertEquals("getWeather", toolCall.name());
+		assertTrue(toolCall.arguments().isEmpty());
+	}
+
+	@Test
+	void testWithArgumentDoesNotMutateOriginal()
+	{
+		ToolCall original = ToolCall.of("getWeather");
+		ToolCall extended = original.withArgument("city", "Berlin");
+
+		assertTrue(original.arguments().isEmpty());
+		assertEquals(Map.of("city", "Berlin"), extended.arguments());
+	}
+
+	@Test
+	void testWithArgumentsMerges()
+	{
+		ToolCall toolCall = ToolCall.of("getWeather")
+			.withArguments(Map.of("city", "Berlin"))
+			.withArgument("day", "tomorrow");
+
+		assertEquals(Map.of("city", "Berlin", "day", "tomorrow"), toolCall.arguments());
+	}
+
+	@Test
+	void testWithArgumentOverwritesExistingKey()
+	{
+		ToolCall toolCall = ToolCall.of("getWeather")
+			.withArgument("city", "Berlin")
+			.withArgument("city", "Hamburg");
+
+		assertEquals(Map.of("city", "Hamburg"), toolCall.arguments());
+	}
+
+	@Test
+	void testArgumentsAreImmutable()
+	{
+		ToolCall toolCall = ToolCall.of("getWeather").withArgument("city", "Berlin");
+
+		assertThrows(UnsupportedOperationException.class, () -> toolCall.arguments().put("day", "tomorrow"));
+	}
+
+	@Test
+	void testNameIsRequired()
+	{
+		assertThrows(NullPointerException.class, () -> ToolCall.of(null));
+	}
+
+	@Test
+	void testMatchesRequiresEqualNameAndExpectedArgumentsAsSubset()
+	{
+		ToolCall actual = ToolCall.of("getWeather").withArguments(Map.of("city", "Berlin", "day", "tomorrow"));
+
+		assertTrue(ToolCall.of("getWeather").matches(actual));
+		assertTrue(ToolCall.of("getWeather").withArgument("city", "Berlin").matches(actual));
+		assertFalse(ToolCall.of("getWeather").withArgument("city", "Hamburg").matches(actual));
+		assertFalse(ToolCall.of("sendMail").matches(actual));
+	}
+
+	@Test
+	void testEqualsAndHashCode()
+	{
+		EqualsVerifier.forClass(ToolCall.class)
+			.suppress(Warning.NULL_FIELDS)
+			.verify();
+	}
+}

--- a/docusaurus/docs/rage4j-assert/examples.md
+++ b/docusaurus/docs/rage4j-assert/examples.md
@@ -106,6 +106,26 @@ rageAssert.given()
 This example uses the [`assertRougeScore`](/docs/rage4j-core/metrics/rouge_score) feature, with the **ROUGE_L_SUM**
 metric. This example makes sure that the LCS across multiple sentences yields a precision of 0.9.
 
+### Example: Testing Tool Call Accuracy
+
+``` java
+RageAssert rageAssert = new OpenAiLLMBuilder().fromApiKey(key);
+rageAssert.given()
+    .question("Wie wird das Wetter morgen in Berlin?")
+    .expectedToolCall(WeatherTools::getWeather)
+    .withArgument("city", "Berlin")
+    .withArgument("day", "tomorrow")
+    .when()
+    .answerFrom(assistant::chat)
+    .then()
+    .assertToolCallAccuracy(1.0);
+```
+
+This example uses the [`assertToolCallAccuracy`](/docs/rage4j-core/metrics/tool_call_accuracy) feature.
+`expectedToolCall` accepts a method reference to a `@Tool`-annotated method, and `withArgument` declares the arguments
+the call is expected to carry. `answerFrom` calls the AI service once and records both the answer and the tool calls
+it performed.
+
 ### Example: Testing Faithfulness with images
 
 When the system under test consumed images alongside the textual context,

--- a/docusaurus/docs/rage4j-assert/introduction.md
+++ b/docusaurus/docs/rage4j-assert/introduction.md
@@ -127,4 +127,8 @@ additional features from the core API, including:
 - `assertSemanticSimilarity(double minValue)`
 - `assertBleuScore(double minValue)`
 - `assertRougeScore(double minValue, RougeScoreEvaluator.RougeType rougeType, RougeScoreEvaluator.MeasureType measureType)`
+- `assertToolCallAccuracy(double minValue)`
+- `assertToolCallOrder()`
+- `assertNoToolCall()`
+- `assertNoUnexpectedToolCalls()`
 If you're eager to explore more examples, check out the [examples on the next page](/docs/rage4j-assert/examples)! 😊

--- a/docusaurus/docs/rage4j-core/core_concepts.md
+++ b/docusaurus/docs/rage4j-core/core_concepts.md
@@ -24,6 +24,8 @@ A Sample typically consists of:
 - A **context** (optional): additional information related to the question.
 - **Images** (optional): part of the context, forwarded to vision-capable
   evaluators. See [Image support](image_support) for details.
+- **Tool calls** (optional): the tool calls the model actually performed, and the ones the test expects. See
+  [Tool Call Accuracy](metrics/tool_call_accuracy) for details.
 
 ```java
 Sample sampleWithImages = Sample.builder()

--- a/docusaurus/docs/rage4j-core/metrics/overview.md
+++ b/docusaurus/docs/rage4j-core/metrics/overview.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Metrics overview
 
-RAGE4j-Core provides six primary metrics for evaluating LLM responses. Each metric focuses on a different aspect of
+RAGE4j-Core provides seven primary metrics for evaluating LLM responses. Each metric focuses on a different aspect of
 response quality and is implemented through a dedicated evaluator.
 
 ## Basic understanding of the metrics
@@ -24,3 +24,5 @@ response quality and is implemented through a dedicated evaluator.
     - **ROUGE-Lsum**: LCS across sentence pairs (summary-level).
 
   Each variant provides **Precision**, **Recall**, and **F1** scores.
+- **Tool Call Accuracy** (0-1): Fraction of expected tool calls that the model actually performed, matched by tool
+  name and argument values.

--- a/docusaurus/docs/rage4j-core/metrics/tool_call_accuracy.md
+++ b/docusaurus/docs/rage4j-core/metrics/tool_call_accuracy.md
@@ -1,0 +1,70 @@
+# Tool Call Accuracy
+
+**Evaluator**: `ToolCallAccuracyEvaluator`
+
+The Tool Call Accuracy metric measures how many of the tool calls a test expects were actually performed by the
+language model. It compares the expected tool calls of a `Sample` against the tool calls the model reported, without
+involving a language model itself.
+
+An expected call matches an actual one when the tool names are equal and every expected argument is present with an
+equivalent value. Expected arguments are therefore a subset of the actual ones, so an expectation without arguments
+matches any call of the same name. Top level numbers are compared by numeric value, so an `Integer` argument matches
+an equivalent `Long`. Values nested inside a map or list are compared with `equals`, so numbers within them must also
+match in type.
+
+## Required Sample Fields
+
+- `expectedToolCalls` – Required. The tool calls the test expects to have been performed.
+- `toolCalls` – Required. The tool calls the model actually performed.
+
+## How It Works
+
+1. For each expected tool call, searches the actual tool calls for the first one that matches it.
+2. A matched actual call is removed from the pool, so each actual call can satisfy at most one expectation.
+3. The score is the number of matched expectations divided by the total number of expected tool calls.
+4. Additional actual calls that no expectation covers do not lower the score.
+
+Throws `IllegalArgumentException` if the sample has no expected tool calls, or if no actual tool calls were recorded
+on it.
+
+## Score Interpretation
+
+- **Range**: `0.0` (no expected call was performed) to `1.0` (every expected call was performed)
+- **Higher scores** indicate the model performed more of the tool calls a test expects.
+- **Lower scores** indicate the model skipped expected tool calls or called a tool with different arguments than
+  expected.
+- Unexpected extra calls are not penalized by this metric. Use `assertNoUnexpectedToolCalls` if extra calls should
+  fail the test.
+
+## Declaring Expectations by Method Reference
+
+In the fluent assertion API an expected tool call can be declared by pointing at the tool method itself instead of
+naming it as a string:
+
+```java
+rageAssert.given()
+    .question("Wie wird das Wetter morgen in Berlin?")
+    .expectedToolCall(WeatherTools::getWeather)
+    .withArgument("city", "Berlin")
+    .when()
+    .answerFrom(assistant::chat)
+    .then()
+    .assertToolCallAccuracy(1.0);
+```
+
+This keeps the expectation refactoring-safe and honours a `@Tool(name = "...")` override, which a hand-written string
+would get wrong. Two limitations apply:
+
+- **Overloaded tool methods** cannot be referenced this way, because the type of the method reference cannot be
+  inferred. Use the `expectedToolCall(String)` overload for those, and for tools that have no Java method at all, such
+  as MCP tools.
+- **Under JPMS** the module declaring the tool class must be open, because the tool name is resolved by reading the
+  method reference's `writeReplace`. Projects using Rage4J from the classpath are unaffected.
+
+## Example Usage
+
+```java
+ToolCallAccuracyEvaluator evaluator = new ToolCallAccuracyEvaluator();
+Evaluation result = evaluator.evaluate(sample);
+double toolCallAccuracy = result.getValue();
+```

--- a/docusaurus/docs/rage4j-core/metrics/tool_call_accuracy.md
+++ b/docusaurus/docs/rage4j-core/metrics/tool_call_accuracy.md
@@ -19,8 +19,10 @@ match in type.
 
 ## How It Works
 
-1. For each expected tool call, searches the actual tool calls for the first one that matches it.
-2. A matched actual call is removed from the pool, so each actual call can satisfy at most one expectation.
+1. Pairs the expected tool calls with the actual ones so that each actual call satisfies at most one expectation.
+2. The pairing is a maximum matching, not a first-match-wins scan. An expectation without arguments matches any call
+   of its name, and taking the first match would let it consume the very call a more specific expectation of the same
+   tool needs — reporting a failure even though a pairing satisfying both exists.
 3. The score is the number of matched expectations divided by the total number of expected tool calls.
 4. Additional actual calls that no expectation covers do not lower the score.
 


### PR DESCRIPTION
Adds a deterministic metric that asserts which tools a LangChain4j AI service
invoked, and with which arguments — no judge model involved.

```java
rageAssert.given()
    .question("What's the weather in Berlin tomorrow?")
    .expectedToolCall(WeatherTools::getWeather)
    .withArgument("city", "Berlin")
    .withArgument("day", "tomorrow")
    .when()
    .answerFrom(assistant::chat)
    .then()
    .assertToolCallAccuracy(1.0);
```

`answerFrom` calls the AI service once and records both the answer and the tool
calls, so tool call and answer metrics can be asserted on the same invocation.
The expected tool is declared by method reference, which stays correct across
renames and honours a `@Tool(name = "...")` override; a `String` overload covers
MCP and other tools that have no Java method.

Also available: `assertToolCallOrder()`, `assertNoToolCall()`,
`assertNoUnexpectedToolCalls()`, and `withArguments(Map)` /
`withArgumentsJson(String)` for reusable or trace-copied argument sets.